### PR TITLE
Passing constants into Secretary

### DIFF
--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -2,8 +2,9 @@ module Sprockets
   class Environment
     attr_reader :root, :load_path
     
-    def initialize(root, load_path = [])
+    def initialize(root, load_path = [], constants={})
       @load_path = [@root = Pathname.new(self, root)]
+      @initial_constants = constants || {}
 
       load_path.reverse_each do |location|
         register_load_location(location)
@@ -31,11 +32,12 @@ module Sprockets
     
     def constants(reload = false)
       @constants = nil if reload
-      @constants ||= find_all("constants.yml").inject({}) do |constants, pathname|
+      yaml_constants = find_all("constants.yml").inject({}) do |constants, pathname|
         contents = YAML.load(pathname.contents) rescue nil
         contents = {} unless contents.is_a?(Hash)
         constants.merge(contents)
       end
+      @constants ||= yaml_constants.merge(@initial_constants)
     end
     
     protected

--- a/lib/sprockets/secretary.rb
+++ b/lib/sprockets/secretary.rb
@@ -16,7 +16,7 @@ module Sprockets
 
     def reset!(options = @options)
       @options = DEFAULT_OPTIONS.merge(options)
-      @environment  = Sprockets::Environment.new(@options[:root])
+      @environment  = Sprockets::Environment.new(@options[:root], [], @options[:constants])
       @preprocessor = Sprockets::Preprocessor.new(@environment, :strip_comments => @options[:strip_comments])
 
       add_load_locations(@options[:load_path])

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -56,7 +56,13 @@ class EnvironmentTest < Test::Unit::TestCase
     assert_kind_of Hash, constants
     assert_equal %w(HELLO ONE TWO VERSION), constants.keys.sort
   end
-  
+
+  def test_passing_in_constants_to_override_using_constants_in_the_load_path
+    environment = environment_for_fixtures({"VERSION" => 99})
+    assert_equal 99, environment.constants["VERSION"]
+    assert_equal "one", environment.constants["ONE"]
+  end
+
   protected
     def assert_load_path_equals(load_path_absolute_locations, environment)
       assert load_path_absolute_locations.zip(environment.load_path).map { |location, pathname| File.expand_path(location) == pathname.absolute_location }.all?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,8 +15,8 @@ class Test::Unit::TestCase
       IO.read(location_for_fixture(fixture))
     end
   
-    def environment_for_fixtures
-      Sprockets::Environment.new(FIXTURES_PATH, source_directories_in_fixtures_path)
+    def environment_for_fixtures(constants={})
+      Sprockets::Environment.new(FIXTURES_PATH, source_directories_in_fixtures_path, constants)
     end
   
     def source_directories_in_fixtures_path

--- a/test/test_secretary.rb
+++ b/test/test_secretary.rb
@@ -81,7 +81,12 @@ class SecretaryTest < Test::Unit::TestCase
     secretary.add_source_file("src/script_with_comments.js")
     assert_equal content_of_fixture("src/script_with_comments.js"), secretary.concatenation.to_s
   end
-  
+
+  def test_secretary_passing_constants_to_the_environment
+    secretary = Sprockets::Secretary.new(:root => FIXTURES_PATH, :constants => {"VERSION" => 99})
+    assert_equal secretary.environment.constants["VERSION"], 99
+  end
+
   protected
     def paths_relative_to(root, *paths)
       paths.map { |path| File.join(root, path) }


### PR DESCRIPTION
I am using sprockets to concatenate some javascript dynamically and needed to be able to pass in the constants at concatenation time rather than have them in a yaml file.

I added the ability to pass in constants when initialising the secretary.
