### PR TITLE
V2: Allow extra headers from server on delivery

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -6,6 +6,7 @@ module Sprockets
 
     def initialize(environment = Environment.new)
       self.environment = environment
+      @extra_headers = {}
     end
 
     def call(env)
@@ -26,6 +27,10 @@ module Sprockets
       else
         ok_response(asset, env)
       end
+    end
+
+    def extra_headers(headers)
+      @extra_headers = headers
     end
 
     private
@@ -78,7 +83,7 @@ module Sprockets
           if env["QUERY_STRING"] == asset.digest
             headers["Cache-Control"] << ", max-age=31557600"
           end
-        end
+        end.merge(@extra_headers)
       end
 
       def etag(asset)

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -30,6 +30,13 @@ class TestServer < Sprockets::TestCase
     @app ||= default_app
   end
 
+  test "custom headers on server" do
+    javascripts_app.extra_headers('Vary' => 'Accept-Encoding', 'Kurt' => 'Wins')
+
+    get "/javascripts/foo.js"
+    assert_equal "Wins", last_response.headers['Kurt']
+    assert_equal "Accept-Encoding", last_response.headers['Vary']
+  end
   test "serve single source file" do
     get "/javascripts/foo.js"
     assert_equal "var foo;\n", last_response.body


### PR DESCRIPTION
This is primarily so I can use CloudFront from Heroku. CloudFront will handle gzip "properly" if you send a Vary header, which I wanted to be able to specify when I built my Sprockets::Server.
