### PR TITLE
adding rocco with supporting cast of tasks.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,47 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.warning = true
 end
+
+begin
+
+require 'rake/clean'
+# Bring in Rocco tasks
+require 'rocco/tasks'
+Rocco::make 'docs/'
+
+desc 'Build rocco docs'
+task :docs => :rocco
+directory 'docs/'
+
+desc 'Build docs and open in browser for the reading'
+task :read => :docs do
+  sh 'open docs/lib/sprockets.html'
+end
+
+# Alias for docs task
+task :doc => :docs
+
+desc 'Update gh-pages branch'
+task :pages => ['docs/.git', :docs] do
+  rev = `git rev-parse --short HEAD`.strip
+  Dir.chdir 'docs' do
+    sh "git add *.html"
+    sh "git commit -m 'rebuild pages from #{rev}'" do |ok,res|
+      if ok
+        verbose { puts "gh-pages updated" }
+        sh "git push -q o HEAD:gh-pages"
+      end
+    end
+  end
+end
+
+# Update the pages/ directory clone
+file 'docs/.git' => ['docs/', '.git/refs/heads/gh-pages'] do |f|
+  sh "cd docs && git init -q && git remote add o ../.git" if !File.exist?(f.name)
+  sh "cd docs && git fetch -q o && git reset -q --hard o/gh-pages && touch ."
+end
+CLOBBER.include 'docs/.git'
+
+rescue LoadError
+  warn "#$! -- rocco tasks not loaded."
+end

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "execjs"
   s.add_development_dependency "coffee-script"
   s.add_development_dependency "ejs"
+  s.add_development_dependency "rocco"
+  s.add_development_dependency "pygmentize"
 
   s.authors = ["Sam Stephenson", "Joshua Peek"]
   s.email = "sstephenson@gmail.com"


### PR DESCRIPTION
Partially addresses Issue #10.

Basically, this gives you not only a `rake docs` that generates docco, but also `rake pages` which automatically updates the documentation in the gh-pages branch. Generously stolen from the rocco Rakefile.

Fun!
