### PR TITLE
Sprockets fails in environments where ENV["HOME"] is unset

### DIFF
--- a/lib/sprockets/asset_attributes.rb
+++ b/lib/sprockets/asset_attributes.rb
@@ -19,7 +19,7 @@ module Sprockets
 
     def pretty_path
       @pretty_path ||= @pathname.
-        sub(/^#{Regexp.escape(ENV['HOME'])}/, '~').
+        sub(/^#{Regexp.escape(ENV['HOME'] || '')}/, '~').
         sub(/^#{Regexp.escape(environment.root)}\//, '')
     end
 

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -361,6 +361,19 @@ class BundledAssetTest < Sprockets::TestCase
     assert_equal "@charset \"UTF-8\";\n.foo {}\n\n.bar {}\n", asset("charset.css").to_s
   end
 
+  test "should not fail if home is not set in environment" do
+    begin
+      home, ENV["HOME"] = ENV["HOME"], nil
+      assert_nothing_raised do
+        env = Sprockets::Environment.new
+        env.append_path(fixture_path('asset'))
+        env['application.js']
+      end
+    ensure
+      ENV["HOME"] = home
+    end
+  end
+
   def asset(logical_path)
     @env.index[logical_path]
   end


### PR DESCRIPTION
Hi! There is a problem when Sprockets is used in environments where `ENV["HOME"]` is unset. It will lead to errors, even though the home directory is only used for logging.

The error that is raised is: `TypeError: can't convert nil into String`

This patch fixes it by removing the assumption that `ENV["HOME"]` is a string. Test included.
