### PR TITLE
Byte order marks in multiple files results in invalid concatenation

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -73,7 +73,7 @@ module Sprockets
       attributes = environment.attributes_for(pathname)
 
       data    = options[:data] || pathname.read
-      result  = data
+      result  = strip_bom(data)
       engines = options[:engines] || environment.processors(content_type) +
                           attributes.engines.reverse
 
@@ -121,6 +121,14 @@ module Sprockets
 
       def logger
         environment.logger
+      end
+
+      def strip_bom(str)
+        if (str[0..2] == "\xef\xbb\xbf")
+          str[3..-1]
+        else
+          str
+        end
       end
   end
 end

--- a/test/fixtures/asset/bom.js
+++ b/test/fixtures/asset/bom.js
@@ -1,0 +1,1 @@
+﻿var bom = true;

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -290,6 +290,11 @@ class BundledAssetTest < Sprockets::TestCase
     assert_equal 4, asset("unicode.js").length
   end
 
+  test "removes BOM from UTF-8 files" do
+    assert_equal "var bom = true;\n", asset("bom.js").to_s
+  end
+
+
   test "asset digest" do
     assert_equal "35d470ef8621efa573dee227a4feaba3", asset("project.js").digest
   end


### PR DESCRIPTION
When multiple files containing byte order marks (BOM) are concatenated, the result is invalid Unicode as BOM can only exist in the beginning of a Unicode file. BOM doesn't have any meaning for UTF-8, so they are removed altogether.

This is the cause of issue #71.

See: http://en.wikipedia.org/wiki/Byte_order_mark
