### PR TITLE
Body-only asset requests are not getting correct content length for files with multi-byte characters

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -169,7 +169,7 @@ module Sprockets
       # Returns a 200 OK response tuple
       def ok_response(asset, env)
         if body_only?(env)
-          [ 200, headers(env, asset, asset.body.length), [asset.body] ]
+          [ 200, headers(env, asset, Rack::Utils.bytesize(asset.body)), [asset.body] ]
         else
           [ 200, headers(env, asset, asset.length), asset ]
         end


### PR DESCRIPTION
Return the byte-size instead of body.length as Content-Length  for body-only responses to account for multi-byte characters in the JS source.

I had trouble getting a failing test case because the rack response sometimes auto-fills the content-length correctly despite what you return (when @chunked is false). I tried for about 30 minutes which is the limit of my time but figured I'd submit the bug without coverage anyway.
