### PR TITLE
asset precompilation gzips .js and .css files

### DIFF
--- a/lib/sprockets/static_compilation.rb
+++ b/lib/sprockets/static_compilation.rb
@@ -1,8 +1,11 @@
 require 'fileutils'
 require 'pathname'
+require 'zlib'
 
 module Sprockets
   module StaticCompilation
+    EXTS_TO_GZIP = %w(.js .css)
+
     def static_root
       @static_root
     end
@@ -26,18 +29,29 @@ module Sprockets
           if asset = find_asset_in_path(logical_path)
             digest_path = path_with_fingerprint(logical_path, asset.digest)
             filename = @static_root.join(digest_path)
+            content = asset.to_s
 
             FileUtils.mkdir_p filename.dirname
 
             filename.open('wb') do |f|
-              f.write asset.to_s
+              f.write content
             end
+
+            gzip("#{filename}.gz", content) if EXTS_TO_GZIP.include?(filename.extname)
           end
         end
       end
     end
 
     protected
+      def gzip(filename, content)
+        File.open(filename, 'wb') do |f|
+          gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
+          gz.write content
+          gz.close
+        end
+      end
+
       def find_asset_in_static_root(logical_path)
         return unless static_root
 

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -209,12 +209,16 @@ module EnvironmentTests
 
   test "precompile" do
     filename = fixture_path("public/gallery-f1598cfbaf2a26f20367e4046957f6e0.js")
+    filename_gz = "#{filename}.gz"
     begin
       assert !File.exist?(filename)
       @env.precompile("gallery.js")
       assert File.exist?(filename)
+      assert File.exist?(filename_gz)
     ensure
-      File.unlink(filename) if File.exist?(filename)
+      [filename, filename_gz].each do |f|
+        File.unlink(f) if File.exist?(f)
+      end
     end
   end
 
@@ -226,9 +230,11 @@ module EnvironmentTests
       @env.precompile("mobile/*")
 
       assert File.exist?(dirname)
-      assert File.exist?(File.join(dirname, "a-172ecf751b024e2c68b1da265523b202.js"))
-      assert File.exist?(File.join(dirname, "b-5e5f944f87f43e1ddec5c8dc109e5f8d.js"))
-      assert File.exist?(File.join(dirname, "c-4127d837671de30f7e9cb8e9bec82285.css"))
+      [nil, '.gz'].each do |gzipped|
+        assert File.exist?(File.join(dirname, "a-172ecf751b024e2c68b1da265523b202.js#{gzipped}"))
+        assert File.exist?(File.join(dirname, "b-5e5f944f87f43e1ddec5c8dc109e5f8d.js#{gzipped}"))
+        assert File.exist?(File.join(dirname, "c-4127d837671de30f7e9cb8e9bec82285.css#{gzipped}"))
+      end
     ensure
       FileUtils.rm_rf(dirname)
     end
@@ -242,9 +248,11 @@ module EnvironmentTests
       @env.precompile(/mobile\/.*/)
 
       assert File.exist?(dirname)
-      assert File.exist?(File.join(dirname, "a-172ecf751b024e2c68b1da265523b202.js"))
-      assert File.exist?(File.join(dirname, "b-5e5f944f87f43e1ddec5c8dc109e5f8d.js"))
-      assert File.exist?(File.join(dirname, "c-4127d837671de30f7e9cb8e9bec82285.css"))
+      [nil, '.gz'].each do |gzipped|
+        assert File.exist?(File.join(dirname, "a-172ecf751b024e2c68b1da265523b202.js#{gzipped}"))
+        assert File.exist?(File.join(dirname, "b-5e5f944f87f43e1ddec5c8dc109e5f8d.js#{gzipped}"))
+        assert File.exist?(File.join(dirname, "c-4127d837671de30f7e9cb8e9bec82285.css#{gzipped}"))
+      end
     ensure
       FileUtils.rm_rf(dirname)
     end
@@ -256,6 +264,7 @@ module EnvironmentTests
       assert !File.exist?(filename)
       @env.precompile("hello.txt")
       assert File.exist?(filename)
+      assert !File.exist?("#{filename}.gz")
     ensure
       File.unlink(filename) if File.exist?(filename)
     end


### PR DESCRIPTION
This is handy if your web server is configured to check for
compressed files and serve those directly if they exist.
That is done by the gzip_static Nginx module for example,
Apache needs some rewrite rules you can Google for.
