### PR TITLE
Add directive to ignore assets

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -20,6 +20,7 @@ module Sprockets
 
       @_required_paths   = []
       @_dependency_paths = Set.new
+      @_ignored_paths    = Set.new
     end
 
     def root_path
@@ -126,10 +127,19 @@ module Sprockets
     def require_asset(path)
       pathname = resolve(path, :content_type => :self)
 
-      unless @_required_paths.include?(pathname.to_s)
+      unless @_required_paths.include?(pathname.to_s) || @_ignored_paths.include?(pathname.to_s)
         @_dependency_paths << pathname.to_s
         @_required_paths << pathname.to_s
       end
+
+      pathname
+    end
+    
+    def ignore_asset(path)
+      pathname = resolve(path, :content_type => :self)
+
+      @_ignored_paths << pathname.to_s
+      @_required_paths -= [pathname.to_s]
 
       pathname
     end

--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -244,6 +244,18 @@ module Sprockets
         context.require_asset(path)
       end
 
+      def process_ignore_directive(path)
+        if @compat
+          if path =~ /<([^>]+)>/
+            path = $1
+          else
+            path = "./#{path}" unless relative?(path)
+          end
+        end
+
+        context.ignore_asset(path)
+      end
+
       # `require_self` causes the body of the current file to be
       # inserted before any subsequent `require` or `include`
       # directives. Useful in CSS files, where it's common for the

--- a/test/fixtures/context/ignore.js.yml
+++ b/test/fixtures/context/ignore.js.yml
@@ -1,0 +1,5 @@
+require:
+  - foo.js
+  - bar.js
+ignore:
+  - bar.js

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -52,6 +52,11 @@ class TestCustomProcessor < Sprockets::TestCase
       @manifest['require'].each do |logical_path|
         context.require_asset(logical_path)
       end
+
+      (@manifest['ignore'] || []).each do |logical_path|
+        context.ignore_asset(logical_path)
+      end
+
       ""
     end
   end
@@ -60,6 +65,12 @@ class TestCustomProcessor < Sprockets::TestCase
     @env.register_engine :yml, YamlProcessor
 
     assert_equal "var Foo = {};\n\nvar Bar = {};\n", @env['application.js'].to_s
+  end
+
+  test "custom processor using Context#ignore" do
+    @env.register_engine :yml, YamlProcessor
+
+    assert_equal "var Foo = {};\n\n", @env['ignore.js'].to_s
   end
 
   class DataUriProcessor < Tilt::Template


### PR DESCRIPTION
I recently started using sprockets as part of a new Rails 3.1 project. I love it so far, but there are assets that I don't want as part of my bundle, for example an IE only, or print stylesheet that should be included with the appropriate tags in the layout.

I forked and patched the directive processor and context to implement an ignore directive like so:

``` css
/*
*= require "foo"
*= ignore "bar"
*= require_tree .
*/
```

This will NOT include the bar asset even if it finds it when executing require_tree.

Thoughts? Is this the right place to do something like this, or should it happen higher up (say in Rails)?
