### PR TITLE
Allow using a path object rather than a string for environment_index#resolve()

### DIFF
--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -79,6 +79,8 @@ module EnvironmentTests
   test "resolve in environment" do
     assert_equal fixture_path('default/gallery.js'),
       @env.resolve("gallery.js").to_s
+    assert_equal fixture_path('default/gallery.js'),
+      @env.resolve(Pathname.new("gallery.js")).to_s
   end
 
   test "missing file raises an exception" do


### PR DESCRIPTION
In a rails 3.1 config file, using 

config.assets.path << Rails.root.join 'lib', 'javascripts'

will fail to load because the path that gets passed through is a Pathname instead of a string.
This is a pretty trivial change - adding a to_s should be enough.
