### PR TITLE
Allow defining charset in a stylesheet with require directive

### DIFF
--- a/lib/sprockets/charset_normalizer.rb
+++ b/lib/sprockets/charset_normalizer.rb
@@ -26,7 +26,7 @@ module Sprockets
       charset = nil
 
       # Find and strip out any `@charset` definitions
-      filtered_data = data.gsub(/^@charset "([^"]+)";$/) {
+      filtered_data = data.gsub(/^@charset\s+"([^"]+)";\n?$/) {
         charset ||= $1; ""
       }
 

--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -90,7 +90,7 @@ module Sprockets
         # of code will not be processed.
         #
         HEADER_PATTERN = /
-          \A (
+          \A(@charset \s+ "[^"]+" ;)? (
             (?m:\s*) (
               (\/\* (?m:.*?) \*\/) |
               (\#\#\# (?m:.*?) \#\#\#) |

--- a/test/fixtures/asset/charset_with_require.css
+++ b/test/fixtures/asset/charset_with_require.css
@@ -1,0 +1,2 @@
+@charset  "UTF-8";
+//= require one

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -539,6 +539,11 @@ class BundledAssetTest < Sprockets::TestCase
     assert_equal "@charset \"UTF-8\";\n.foo {}\n\n.bar {}\n", asset("charset.css").to_s
   end
 
+  test "charset definition doesn't prevent header parsing" do
+    assert_equal "@charset \"UTF-8\";.one {}\n",
+      asset("charset_with_require.css").to_s
+  end
+
   test "appends missing semicolons" do
     assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n;\n",
       asset("semicolons.js").to_s


### PR DESCRIPTION
Let's give rails users a chance to set @charset directive inside application.css.
