### PR TITLE
require_tree ignore vim backup file

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -287,6 +287,8 @@ module Sprockets
           Dir["#{root}/*"].sort.each do |filename|
             if filename == self.file
               next
+						elsif filename =~ /~$/
+							next
             elsif context.asset_requirable?(filename)
               context.require_asset(filename)
             end
@@ -310,6 +312,8 @@ module Sprockets
           Dir["#{root}/**/*"].sort.each do |filename|
             if filename == self.file
               next
+						elsif filename =~ /~$/
+							next
             elsif File.directory?(filename)
               context.depend_on(filename)
             elsif context.asset_requirable?(filename)


### PR DESCRIPTION
by default, require_tree include vim backup file.

please see this thread https://github.com/rails/rails/issues/1863#issuecomment-1543809
