### PR TITLE
Use hash instead of encoded file path as file name for temp files 

### DIFF
--- a/lib/sprockets/caching.rb
+++ b/lib/sprockets/caching.rb
@@ -68,7 +68,8 @@ module Sprockets
       # Removes `Environment#root` from key and prepends
       # `Environment#cache_key_namespace`.
       def cache_key_for(key)
-        digest.hexdigest(File.join(cache_key_namespace, key.sub(root, '')))
+        hash = digest.hexdigest(File.join(cache_key_namespace, key.sub(root, '')))
+        "#{cache_key_namespace}/#{hash}"
       end
 
       def cache_get_hash(key, version)


### PR DESCRIPTION
As sprockets would use the encoded file path as file name for temp files,
these filenames can become very long if the number of sub directories is high.
This becomes a problem on linux filesystems as the filename limit is 255 characters.

I originally posted an issue in rails:
https://github.com/rails/rails/issues/2308
