### PR TITLE
Pass a String to MD5::Digest.file because jruby barfs on a Pathname.

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -72,7 +72,7 @@ module Sprockets
 
         # If its a file, digest the contents
         elsif stat.file?
-          digest.file(path)
+          digest.file(path.to_s)
 
         # If its a directive, digest the list of filenames
         elsif stat.directory?


### PR DESCRIPTION
Currently prevents you from using jruby to run `rake assets:precompile`.
My fix was to convert the `Pathname` instance to a string, not sure if there is a better way to fix this.

```
$ rake assets:precompile --trace
** Invoke assets:precompile (first_time)
** Invoke assets:ensure_env (first_time)
** Execute assets:ensure_env
** Execute assets:precompile
** Invoke environment (first_time)
** Execute environment
rake aborted!
can't convert Pathname into String
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/base.rb:75:in `file_digest'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:42:in `file_digest'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:77:in `memoize'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:42:in `file_digest'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/asset.rb:81:in `digest'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/static_asset.rb:83:in `load!'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/static_asset.rb:18:in `initialize'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/base.rb:130:in `build_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:69:in `build_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/caching.rb:46:in `cache_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:68:in `build_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:77:in `memoize'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:66:in `build_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/trail.rb:111:in `find_asset_in_path'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/base.rb:102:in `find_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/index.rb:49:in `find_asset'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/static_compilation.rb:44:in `precompile'
/Users/samuelkadolph/.rvm/rubies/jruby-1.6.3/lib/ruby/1.9/set.rb:222:in `each'
org/jruby/RubyHash.java:1236:in `each_key'
/Users/samuelkadolph/.rvm/rubies/jruby-1.6.3/lib/ruby/1.9/set.rb:222:in `each'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/static_compilation.rb:35:in `precompile'
org/jruby/RubyArray.java:1603:in `each'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/sprockets-2.0.0.beta.12/lib/sprockets/static_compilation.rb:34:in `precompile'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/actionpack-3.1.0.rc5/lib/sprockets/assets.rake:14:in `(root)'
org/jruby/RubyProc.java:256:in `call'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/task.rb:205:in `execute'
org/jruby/RubyArray.java:1603:in `each'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/task.rb:200:in `execute'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/task.rb:158:in `invoke_with_call_chain'
/Users/samuelkadolph/.rvm/rubies/jruby-1.6.3/lib/ruby/1.9/monitor.rb:201:in `mon_synchronize'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/task.rb:151:in `invoke_with_call_chain'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/task.rb:144:in `invoke'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:112:in `invoke_task'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:90:in `top_level'
org/jruby/RubyArray.java:1603:in `each'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:90:in `top_level'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:129:in `standard_exception_handling'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:84:in `top_level'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:62:in `run'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:129:in `standard_exception_handling'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/lib/rake/application.rb:59:in `run'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/gems/rake-0.9.2/bin/rake:32:in `(root)'
org/jruby/RubyKernel.java:1073:in `load'
/Users/samuelkadolph/.rvm/gems/jruby-1.6.3/bin/rake:19:in `(root)'
Tasks: TOP => assets:precompile
```
