### PR TITLE
Make the asset precompilation helper return a manifest of all the assets 

### DIFF
--- a/lib/sprockets/static_compilation.rb
+++ b/lib/sprockets/static_compilation.rb
@@ -31,6 +31,7 @@ module Sprockets
     def precompile(*paths)
       raise "missing static root" unless static_root
 
+      manifest = {}
       paths.each do |path|
         files.each do |logical_path|
           if path.is_a?(Regexp)
@@ -46,6 +47,8 @@ module Sprockets
             digest_path = attributes.path_with_fingerprint(asset.digest)
             filename    = static_root.join(digest_path)
 
+            manifest[logical_path] = digest_path
+
             # Ensure directory exists
             FileUtils.mkdir_p filename.dirname
 
@@ -57,6 +60,7 @@ module Sprockets
           end
         end
       end
+      manifest
     end
 
     private

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -204,9 +204,10 @@ module EnvironmentTests
 
     sandbox filename, filename_gz do
       assert !File.exist?(filename)
-      @env.precompile("gallery.js")
+      manifest = @env.precompile("gallery.js")
       assert File.exist?(filename)
       assert File.exist?(filename_gz)
+      assert_equal "gallery-#{digest}.js", manifest["gallery.js"]
     end
   end
 
@@ -219,7 +220,7 @@ module EnvironmentTests
 
     sandbox dirname do
       assert !File.exist?(dirname)
-      @env.precompile("mobile/*")
+      manifest = @env.precompile("mobile/*")
 
       assert File.exist?(dirname)
       [nil, '.gz'].each do |gzipped|
@@ -227,6 +228,9 @@ module EnvironmentTests
         assert File.exist?(File.join(dirname, "b-#{b_digest}.js#{gzipped}"))
         assert File.exist?(File.join(dirname, "c-#{c_digest}.css#{gzipped}"))
       end
+      assert_equal "mobile/a-#{a_digest}.js", manifest["mobile/a.js"]
+      assert_equal "mobile/b-#{b_digest}.js", manifest["mobile/b.js"]
+      assert_equal "mobile/c-#{c_digest}.css", manifest["mobile/c.css"]
     end
   end
 
@@ -239,7 +243,7 @@ module EnvironmentTests
 
     sandbox dirname do
       assert !File.exist?(dirname)
-      @env.precompile(/mobile\/.*/)
+      manifest = @env.precompile(/mobile\/.*/)
 
       assert File.exist?(dirname)
       [nil, '.gz'].each do |gzipped|
@@ -247,6 +251,9 @@ module EnvironmentTests
         assert File.exist?(File.join(dirname, "b-#{b_digest}.js#{gzipped}"))
         assert File.exist?(File.join(dirname, "c-#{c_digest}.css#{gzipped}"))
       end
+      assert_equal "mobile/a-#{a_digest}.js", manifest["mobile/a.js"]
+      assert_equal "mobile/b-#{b_digest}.js", manifest["mobile/b.js"]
+      assert_equal "mobile/c-#{c_digest}.css", manifest["mobile/c.css"]
     end
   end
 
@@ -256,9 +263,10 @@ module EnvironmentTests
 
     sandbox filename do
       assert !File.exist?(filename)
-      @env.precompile("hello.txt")
+      manifest = @env.precompile("hello.txt")
       assert File.exist?(filename)
       assert !File.exist?("#{filename}.gz")
+      assert_equal "hello-#{digest}.txt", manifest["hello.txt"]
     end
   end
 


### PR DESCRIPTION
Hey guys,

I've got a situation where I need fast access to all the 'stamped' asset names generated by precompilation.  There's not really a simple way to then try and iterate over 'all the assets you precompiled' without working with some private methods and even then that's only true if they haven't expired from the cache in the meantime.

The return value of precompile is currently unused so it seems that we could just keep track while precompiling and return the values to the user in a hash?
