### PR TITLE
Directories should not be yielded when iterating over files/logical paths

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -115,7 +115,7 @@ module Sprockets
       return to_enum(__method__) unless block_given?
       paths.each do |base_path|
         Dir["#{base_path}/**/*"].each do |filename|
-          yield filename
+          yield filename unless File.directory?(filename)
         end
       end
       nil

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -171,13 +171,13 @@ module EnvironmentTests
     @env.each_file do |filename|
       files << filename
     end
-    assert_equal 23, files.length
+    assert_equal 21, files.length
   end
 
   test "each file enumerator" do
     files = []
     enum = @env.each_file
-    assert_equal 23, enum.to_a.length
+    assert_equal 21, enum.to_a.length
   end
 
   test "iterate over each logical path" do
@@ -185,18 +185,19 @@ module EnvironmentTests
     @env.each_logical_path do |logical_path|
       paths << logical_path
     end
-    assert_equal 23, paths.length
+    assert_equal 21, paths.length
     assert_equal paths.size, paths.uniq.size, "has duplicates"
 
     assert paths.include?("application.js")
     assert paths.include?("coffee/foo.js")
     assert paths.include?("coffee/index.js")
+    assert !paths.include?("coffee")
   end
 
   test "each logical path enumerator" do
     files = []
     enum = @env.each_logical_path
-    assert_equal 23, enum.to_a.length
+    assert_equal 21, enum.to_a.length
   end
 
   test "CoffeeScript files are compiled in a closure" do


### PR DESCRIPTION
`Sprockets::Base#each_file` and `#each_logical_path` currently yield all files including directories.

This causes issues in precompilation when a directory with the same base name as a file exists.
- There exists files `admin.css` and `admin/test.css`
- `#each_logical_path` yields `admin`, `admin.css` and `admin/test.css`
- The current precompile task in Rails attempts to compile the directory `admin`, but actually finds and compiles `admin.css` with the target filename `admin`
- Precompiling `admin/test.css` then fails as it cannot create the `admin` directory

This patch ensures that the `admin` directory does not get yielded.
