### PR TITLE
Extended config.ru example instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ way to do this is with the `map` method in `config.ru`:
       environment.append_path 'app/assets/stylesheets'
       run environment
     end
+    
+    map '/' do
+      run YourRackApp
+    end
 
 ### Accessing Assets Programmatically ###
 


### PR DESCRIPTION
When adding sprockets to a Sinatra app, I kept getting weird Rack exceptions until I finally figured out that you have to map your app to '/' instead of directly doing a plain `run`. To avoid other people bumping into this as well, I added this to the Rack example.
