### PR TITLE
Fix AssetAttributes#path_fingerprint. It seem to return incorrect value.

### DIFF
--- a/lib/sprockets/asset_attributes.rb
+++ b/lib/sprockets/asset_attributes.rb
@@ -120,7 +120,7 @@ module Sprockets
     #     # => "0aa2105d29558f3eb790d411d7d8fb66"
     #
     def path_fingerprint
-      pathname.basename(extensions.join).to_s =~ /-([0-9a-f]{7,40})$/ ? $1 : nil
+      pathname.basename("#{format_extension}#{engine_extensions.join}").to_s =~ /-([0-9a-f]{7,40})$/ ? $1 : nil
     end
 
     # Injects digest fingerprint into path.

--- a/test/test_asset_attributes.rb
+++ b/test/test_asset_attributes.rb
@@ -111,6 +111,8 @@ class TestAssetAttributes < Sprockets::TestCase
     assert_equal nil, pathname("foo.js").path_fingerprint
     assert_equal "0aa2105d29558f3eb790d411d7d8fb66",
       pathname("foo-0aa2105d29558f3eb790d411d7d8fb66.js").path_fingerprint
+    assert_equal "0aa2105d29558f3eb790d411d7d8fb66",
+      pathname("foo.bar-0aa2105d29558f3eb790d411d7d8fb66.js").path_fingerprint
   end
 
   test "inject path fingerprint" do


### PR DESCRIPTION
I fixed AssetAttributes#path_fingerprint.
It seem to return incorrect value when pathname has a filename included multiple period.
Please see also https://github.com/rails/rails/issues/3398
