### PR TITLE
Cache keys comes with "sprockets/" prefix, so create that folder beforehand

### DIFF
--- a/lib/sprockets/cache/file_store.rb
+++ b/lib/sprockets/cache/file_store.rb
@@ -6,14 +6,14 @@ module Sprockets
   module Cache
     # A simple file system cache store.
     #
-    #     environment.cache = Sprockets::Cache::FileStore.new("tmp/sprockets")
+    #     environment.cache = Sprockets::Cache::FileStore.new("tmp/")
     #
     class FileStore
       def initialize(root)
         @root = Pathname.new(root)
 
         # Ensure directory exists
-        FileUtils.mkdir_p @root
+        FileUtils.mkdir_p @root.join 'sprockets'
       end
 
       # Lookup value in cache


### PR DESCRIPTION
But cache keys probably shouldn't come with that prefix.. 
