### PR TITLE
Pass also original filename to the block in each_logical_path

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -215,7 +215,7 @@ module Sprockets
       files = {}
       each_file do |filename|
         logical_path = attributes_for(filename).logical_path
-        yield logical_path unless files[logical_path]
+        yield logical_path, filename.to_s unless files[logical_path]
         files[logical_path] = true
       end
       nil

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -184,8 +184,10 @@ module EnvironmentTests
 
   test "iterate over each logical path" do
     paths = []
-    @env.each_logical_path do |logical_path|
+    filenames = []
+    @env.each_logical_path do |logical_path, original_filename|
       paths << logical_path
+      filenames << original_filename
     end
     assert_equal 29, paths.length
     assert_equal paths.size, paths.uniq.size, "has duplicates"
@@ -194,6 +196,8 @@ module EnvironmentTests
     assert paths.include?("coffee/foo.js")
     assert paths.include?("coffee/index.js")
     assert !paths.include?("coffee")
+
+    assert filenames.any? { |p| p =~ /application.js.coffee/ }
   end
 
   test "each logical path enumerator" do


### PR DESCRIPTION
This may be useful if you want to check the original extension of a given file while iterating through logical paths.
