### PR TITLE
Make original path passed to each_logical_file's block relative to root_path

### DIFF
--- a/lib/sprockets/asset_attributes.rb
+++ b/lib/sprockets/asset_attributes.rb
@@ -32,12 +32,16 @@ module Sprockets
     # shaddowed in the path, but is required relatively, its logical
     # path will be incorrect.
     def logical_path
+      path = relative_path
+      path = engine_extensions.inject(path) { |p, ext| p.sub(ext, '') }
+      path = "#{path}#{engine_format_extension}" unless format_extension
+      path
+    end
+
+    # Returns path relative to the root_path
+    def relative_path
       if root_path = environment.paths.detect { |path| pathname.to_s[path] }
-        path = pathname.to_s.sub("#{root_path}/", '')
-        path = pathname.relative_path_from(Pathname.new(root_path)).to_s
-        path = engine_extensions.inject(path) { |p, ext| p.sub(ext, '') }
-        path = "#{path}#{engine_format_extension}" unless format_extension
-        path
+        pathname.relative_path_from(Pathname.new(root_path)).to_s
       else
         raise FileOutsidePaths, "#{pathname} isn't in paths: #{environment.paths.join(', ')}"
       end

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -214,8 +214,10 @@ module Sprockets
       return to_enum(__method__) unless block_given?
       files = {}
       each_file do |filename|
-        logical_path = attributes_for(filename).logical_path
-        yield logical_path, filename.to_s unless files[logical_path]
+        attributes = attributes_for(filename)
+        logical_path = attributes.logical_path
+        relative_path = attributes.relative_path
+        yield logical_path, relative_path unless files[logical_path]
         files[logical_path] = true
       end
       nil

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -197,7 +197,10 @@ module EnvironmentTests
     assert paths.include?("coffee/index.js")
     assert !paths.include?("coffee")
 
-    assert filenames.any? { |p| p =~ /application.js.coffee/ }
+    assert filenames.include?("application.js.coffee")
+    assert filenames.include?("coffee/foo.coffee")
+    assert filenames.include?("coffee/index.js")
+    assert !filenames.include?("coffee")
   end
 
   test "each logical path enumerator" do


### PR DESCRIPTION
After submitting the last pull request I realized that it's wrong in terms of conventions, the path passed to each_logical_file's block is relative to rails root, while new path, passed as a second argument is absolute. This commit fixes the issue to make both paths relative, to make any checks easier.

Sorry for confusion, at first I thought that having entire path will be better, but we should not care about rest of the path.
