### PR TITLE
statuscode=404 for files named "-82edb07.js" (and possibly others..)

### DIFF
--- a/test/fixtures/server/app/javascripts/-82edb07.js
+++ b/test/fixtures/server/app/javascripts/-82edb07.js
@@ -1,0 +1,2 @@
+// this file should be served
+// and status code should not be 404

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -180,6 +180,11 @@ class TestServer < Sprockets::TestCase
     get "/assets/%E6%97%A5%E6%9C%AC%E8%AA%9E.js"
     assert_equal "var japanese = \"日本語\";\n", last_response.body
   end
+  
+  test "serve strange pathname (-82edb07.js)" do
+    get "/assets/-82edb07.js?body=1"
+    assert_equal 200, last_response.status
+  end
 
   test "illegal require outside load path" do
     get "/assets/../config/passwd"


### PR DESCRIPTION
i had a file in my rails app named

```
 app/assets/javascripts/-82edb07.js
```

after upgrading from rails 3.1 to 3.2 i noticed that won't be served any longer by sprockets

i don't know why this is and there are possibly more filenames concerned.

i added a testcase to proove this issue.
