### PR TITLE
Add date header to assets

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -203,6 +203,7 @@ module Sprockets
           headers["Cache-Control"]  = "public"
           headers["Last-Modified"]  = asset.mtime.httpdate
           headers["ETag"]           = etag(asset)
+          headers["Date"]           = Time.now.httpdate
 
           # If the request url contains a fingerprint, set a long
           # expires on the response


### PR DESCRIPTION
HTTP Spec [requires the date header](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18) to be set on all appropriate responses.  Furthermore, some CDNs [have issues caching assets without a Date header](https://forums.aws.amazon.com/thread.jspa?threadID=77579).

Wasn't sure if this is something you'd add a test for, it's a pretty innocuous change.
