### PR TITLE
Make Sprockets not die confusingly when a symlink points to a non-existent path.

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -184,11 +184,14 @@ module Sprockets
       paths = []
       entries(root).sort.each do |filename|
         path = root.join(filename)
-        paths << path
+        path_info = stat(path)
+        if path_info
+          paths << path
 
-        if stat(path).directory?
-          each_entry(path) do |subpath|
-            paths << subpath
+          if path_info.directory?
+            each_entry(path) do |subpath|
+              paths << subpath
+            end
           end
         end
       end


### PR DESCRIPTION
An alternative that may be less confusing (though possibly more _frustrating_) would be to raise an exception here that is more informative.
