### PR TITLE
Check for directory traversal after unescaping

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -25,11 +25,6 @@ module Sprockets
 
       msg = "Served asset #{env['PATH_INFO']} -"
 
-      # URLs containing a `".."` are rejected for security reasons.
-      if forbidden_request?(env)
-        return forbidden_response
-      end
-
       # Mark session as "skipped" so no `Set-Cookie` header is set
       env['rack.session.options'] ||= {}
       env['rack.session.options'][:defer] = true
@@ -37,6 +32,11 @@ module Sprockets
 
       # Extract the path from everything after the leading slash
       path = unescape(env['PATH_INFO'].to_s.sub(/^\//, ''))
+
+      # URLs containing a `".."` are rejected for security reasons.
+      if forbidden_request?(path)
+        return forbidden_response
+      end
 
       # Strip fingerprint
       if fingerprint = path_fingerprint(path)
@@ -85,12 +85,12 @@ module Sprockets
     end
 
     private
-      def forbidden_request?(env)
+      def forbidden_request?(path)
         # Prevent access to files elsewhere on the file system
         #
         #     http://example.org/assets/../../../etc/passwd
         #
-        env["PATH_INFO"].include?("..")
+        path.include?("..")
       end
 
       # Returns a 403 Forbidden response tuple

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -185,6 +185,9 @@ class TestServer < Sprockets::TestCase
   test "illegal require outside load path" do
     get "/assets/../config/passwd"
     assert_equal 403, last_response.status
+
+    get "/assets/%2e%2e/config/passwd"
+    assert_equal 403, last_response.status
   end
 
   test "add new source to tree" do


### PR DESCRIPTION
The `forbidden_request?` check could be trivially bypassed by percent
encoding .. as %2e%2e.

After auditing Sprockets and Hike and fuzzing a simple server, I don't
believe this is exploitable. However, better safe than sorry/defense in
depth/etc.
