### PR TITLE
Ruby 2.0 will return false for respond_to? on protected methods

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -126,7 +126,7 @@ module Sprockets
       @directives ||= header.lines.each_with_index.map { |line, index|
         if directive = line[DIRECTIVE_PATTERN, 1]
           name, *args = Shellwords.shellwords(directive)
-          if respond_to?("process_#{name}_directive")
+          if respond_to?("process_#{name}_directive", true)
             [index + 1, name, *args]
           end
         end


### PR DESCRIPTION
Ruby 2.0 will return false for respond_to? on protected methods unless `true` is passed for the second argument.

  https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/34580
