### PR TITLE
Fix Context#logical_path when path contains periods

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -53,7 +53,7 @@ module Sprockets
     #     # => 'application'
     #
     def logical_path
-      @logical_path[/^([^.]+)/, 0]
+      @logical_path.chomp(File.extname(@logical_path))
     end
 
     # Returns content type of file

--- a/test/fixtures/context/properties.with.periods.js.erb
+++ b/test/fixtures/context/properties.with.periods.js.erb
@@ -1,0 +1,7 @@
+{
+  "pathname" : "<%= pathname %>",
+  "__FILE__" : "<%= __FILE__ %>",
+  "root_path" : "<%= root_path %>",
+  "logical_path" : "<%= logical_path %>",
+  "content_type" : "<%= content_type %>"
+};

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -25,6 +25,17 @@ class TestContext < Sprockets::TestCase
     }, YAML.load(json))
   end
 
+  test "source file properties are exposed in context when path contains periods" do
+    json = @env["properties.with.periods.js"].to_s.chomp.chop
+    assert_equal({
+      'pathname'     => fixture_path("context/properties.with.periods.js.erb"),
+      '__FILE__'     => fixture_path("context/properties.with.periods.js.erb"),
+      'root_path'    => fixture_path("context"),
+      'logical_path' => "properties.with.periods",
+      'content_type' => "application/javascript"
+    }, YAML.load(json))
+  end
+
   test "extend context" do
     @env.context_class.class_eval do
       def datauri(path)


### PR DESCRIPTION
Without this, the `logical_path` only grabbed up up until the first period encountered. So if you happened to have a file like `jquery.mobile-1.0.1/jquery.mobile-1.0.1.js` it's logical path was being interpreted as just `jquery` instead of `jquery.mobile-1.0.1/jquery.mobile-1.0.1`.

I'm not super familiar with the inner-workings of sprockets, so I'm not entirely sure where Context#logical_path is being used, but [sprockets-urlrewriter](https://github.com/carlhoerberg/sprockets-urlrewriter) uses this `logical_path` method and expects it to be the relative path to the asset file. This was obviously leading to strange results since parts of the path might be missing if the file name or path happened to contain periods. And I didn't see any other obvious way to get this type of relative path to the asset file inside a Processor subclass.
