### PR TITLE
Only set a :cache_store for Sass::Engine if there's a cache

### DIFF
--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -26,7 +26,7 @@ module Sprockets
 
     def evaluate(context, locals, &block)
       # Use custom importer that knows about Sprockets Caching
-      cache_store = SassCacheStore.new(context.environment)
+      cache_store = context.environment.cache && SassCacheStore.new(context.environment)
 
       options = {
         :filename => eval_file,


### PR DESCRIPTION
If a Sprockets environment doesn't have a cache set and a SassCacheStore is used, Sass will not use any caching. It would be better to set `:sass_cache => nil` in this case so Sass will use its default caching.
