### PR TITLE
Fix Context#resolve for absolute paths

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -77,32 +77,34 @@ module Sprockets
     #     # => "/path/to/app/javascripts/bar.js"
     #
     def resolve(path, options = {}, &block)
-      pathname   = Pathname.new(path)
-      attributes = environment.attributes_for(pathname)
+      attributes = environment.attributes_for(path)
+      pathname = attributes.pathname
 
       if pathname.absolute?
-        pathname
-
-      elsif content_type = options[:content_type]
-        content_type = self.content_type if content_type == :self
-
-        if attributes.format_extension
-          if content_type != attributes.content_type
-            raise ContentTypeMismatch, "#{path} is " +
-              "'#{attributes.content_type}', not '#{content_type}'"
-          end
-        end
-
-        resolve(path) do |candidate|
-          if self.content_type == environment.content_type_of(candidate)
-            return candidate
-          end
-        end
-
-        raise FileNotFound, "couldn't find file '#{path}'"
+        return pathname if pathname.exist?
       else
-        environment.resolve(path, {:base_path => self.pathname.dirname}.merge(options), &block)
+        if content_type = options[:content_type]
+          content_type = self.content_type if content_type == :self
+
+          if attributes.format_extension
+            if content_type != attributes.content_type
+              raise ContentTypeMismatch, "#{path} is " +
+                "'#{attributes.content_type}', not '#{content_type}'"
+            end
+          end
+
+          resolve(path) do |candidate|
+            if self.content_type == environment.content_type_of(candidate)
+              return candidate
+            end
+          end
+
+        else
+          return environment.resolve(path, {:base_path => self.pathname.dirname}.merge(options), &block)
+        end
       end
+
+      raise FileNotFound, "couldn't find file '#{path}'"
     end
 
     # `depend_on` allows you to state a dependency on a file without

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -8,6 +8,30 @@ class TestContext < Sprockets::TestCase
     @env.append_path(fixture_path('context'))
   end
 
+  test "resolve logical path" do
+    logical_path = "bar.js"
+    path = File.join(fixture_path('context'), logical_path)
+    pathname = Pathname.new(path)
+    context = @env.context_class.new(@env, logical_path, pathname)
+
+    # absolute paths
+    assert_equal context.resolve(path), pathname
+    assert_raise Sprockets::FileNotFound do
+      context.resolve File.join(fixture_path('context'), "wrongname")
+    end
+
+    # with options
+    assert_equal context.resolve(logical_path, :content_type => "application/javascript"), pathname
+    assert_raise Sprockets::ContentTypeMismatch do
+      context.resolve logical_path, :content_type => "text/css"
+    end
+    assert_equal context.resolve(logical_path, :content_type => :self), pathname
+
+    # logical paths
+    assert_equal context.resolve(logical_path), pathname
+    assert_raise(Sprockets::FileNotFound) { context.resolve("wrongname") }
+  end
+
   test "context environment is indexed" do
     instances = @env["environment.js"].to_s.split("\n")
     assert_match "Sprockets::Index", instances[0]


### PR DESCRIPTION
Hi I've added checking for file existence when filename given as absolute path and also added tests for Context#resolve method.
This is backtrace for this issue:

```
ERROR NoMethodError: undefined method `mtime' for nil:NilClass
./sprockets/lib/sprockets/processed_asset.rb:128:in `block in build_dependency_paths'
./sprockets/lib/sprockets/processed_asset.rb:127:in `build_dependency_paths'
./sprockets/lib/sprockets/processed_asset.rb:17:in `initialize'
./sprockets/lib/sprockets/base.rb:340:in `new'
./sprockets/lib/sprockets/base.rb:340:in `block in build_asset'
./sprockets/lib/sprockets/base.rb:361:in `circular_call_protection'
./sprockets/lib/sprockets/base.rb:339:in `build_asset'
./sprockets/lib/sprockets/index.rb:93:in `block in build_asset'
./sprockets/lib/sprockets/caching.rb:51:in `cache_asset'
./sprockets/lib/sprockets/index.rb:92:in `build_asset'
./sprockets/lib/sprockets/base.rb:260:in `find_asset'
./sprockets/lib/sprockets/index.rb:60:in `find_asset'
./sprockets/lib/sprockets/bundled_asset.rb:16:in `initialize'
./sprockets/lib/sprockets/base.rb:343:in `new'
./sprockets/lib/sprockets/base.rb:343:in `build_asset'
./sprockets/lib/sprockets/index.rb:93:in `block in build_asset'
./sprockets/lib/sprockets/caching.rb:51:in `cache_asset'
./sprockets/lib/sprockets/index.rb:92:in `build_asset'
./sprockets/lib/sprockets/base.rb:260:in `find_asset'
./sprockets/lib/sprockets/index.rb:60:in `find_asset'
./sprockets/lib/sprockets/environment.rb:74:in `find_asset'
./sprockets/lib/sprockets/server.rb:47:in `call'
```
