### PR TITLE
Prevent gzip files from being gratuitously different.

### DIFF
--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -145,7 +145,7 @@ module Sprockets
         if options[:compress]
           # Run contents through `Zlib`
           gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
-          gz.mtime = 1
+          gz.mtime = mtime.to_i
           gz.write to_s
           gz.close
         else

--- a/lib/sprockets/static_asset.rb
+++ b/lib/sprockets/static_asset.rb
@@ -30,7 +30,7 @@ module Sprockets
         pathname.open('rb') do |rd|
           File.open("#{filename}+", 'wb') do |wr|
             gz = Zlib::GzipWriter.new(wr, Zlib::BEST_COMPRESSION)
-            gz.mtime = 1
+            gz.mtime = mtime.to_i
             buf = ""
             while rd.read(16384, buf)
               gz.write(buf)


### PR DESCRIPTION
By default, mtime is `0` and in that case, `Zlib` will set it to `Time.now`, and each time the same uncompressed file is compressed, the output will be different. So I chose another integer, `1` seemed nice, but any would do, it just needs to be the same every time.
