### PR TITLE
Make `expire_index!` public

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -323,12 +323,12 @@ module Sprockets
         ">"
     end
 
-    protected
-      # Clear index after mutating state. Must be implemented by the subclass.
-      def expire_index!
-        raise NotImplementedError
-      end
+    # Clear index after mutating state. Must be implemented by the subclass.
+    def expire_index!
+      raise NotImplementedError
+    end
 
+    protected
       def build_asset(logical_path, pathname, options)
         pathname = Pathname.new(pathname)
 

--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -77,11 +77,10 @@ module Sprockets
       end
     end
 
-    protected
-      def expire_index!
-        # Clear digest to be recomputed
-        @digest = nil
-        @assets = {}
-      end
+    def expire_index!
+      # Clear digest to be recomputed
+      @digest = nil
+      @assets = {}
+    end
   end
 end

--- a/lib/sprockets/index.rb
+++ b/lib/sprockets/index.rb
@@ -73,12 +73,13 @@ module Sprockets
       end
     end
 
+    # Index is immutable, any methods that try to clear the cache
+    # should bomb.
+    def expire_index!
+      raise TypeError, "can't modify immutable index"
+    end
+
     protected
-      # Index is immutable, any methods that try to clear the cache
-      # should bomb.
-      def expire_index!
-        raise TypeError, "can't modify immutable index"
-      end
 
       # Cache asset building in memory and in persisted cache.
       def build_asset(path, pathname, options)

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -589,4 +589,10 @@ class TestIndex < Sprockets::TestCase
     assert env.engines[".foo"]
     assert_nil index.engines[".foo"]
   end
+
+  test "expiring index raises an error" do
+    assert_raises TypeError do
+      @env.index.expire_index!
+    end
+  end
 end


### PR DESCRIPTION
Expire index should be made public to allow clearing environment cache
if needed.

I need it specifically to achieve this:
https://github.com/rails/sprockets-rails/pull/8
