### PR TITLE
more specific directive pattern to work around issue with constant interpolation 

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -65,7 +65,7 @@ module Sprockets
     #     //= require "foo"
     #
     DIRECTIVE_PATTERN = /
-      ^ [\s*\/]* = \s* (\w+.*?) (\*\/)? $
+      ^ [\s*#\/]* = \s* (\w+.*?) (\*\/)? $
     /x
 
     attr_reader :pathname


### PR DESCRIPTION
Sprockets does constant interpolation after the source has been processed. This means that comments may have lines that look like:

<pre> *  "&lt;%= PROTOTYPE_VERSION %&gt;"). The famous</pre>


This commit makes the directive pattern more specific to avoid matching lines like this. Another approach could be to do the variable interpolation before processing the source.
