### PR TITLE
Refactor duplicate patterns in Sprockets::Processing module

### DIFF
--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -137,10 +137,7 @@ module Sprockets
 
     # Return CSS compressor or nil if none is set
     def css_compressor
-      bundle_processors('text/css').detect { |klass|
-        klass.respond_to?(:name) &&
-          klass.name == 'Sprockets::Processor (css_compressor)'
-      }
+      find_compressor('text/css', :css_compressor)
     end
 
     # Assign a compressor to run on `text/css` assets.
@@ -152,10 +149,7 @@ module Sprockets
 
     # Return JS compressor or nil if none is set
     def js_compressor
-      bundle_processors('application/javascript').detect { |klass|
-        klass.respond_to?(:name) &&
-          klass.name == 'Sprockets::Processor (js_compressor)'
-      }
+      find_compressor('application/javascript', :js_compressor)
     end
 
     # Assign a compressor to run on `application/javascript` assets.
@@ -195,6 +189,13 @@ module Sprockets
         end
 
         processors[mime_type].delete(klass)
+      end
+
+      def find_compressor(mime_type, name)
+        bundle_processors(mime_type).detect { |klass|
+          klass.respond_to?(:name) &&
+            klass.name == "Sprockets::Processor (#{name})"
+        }
       end
 
       def assign_compressor(mime_type, klass, compressor)


### PR DESCRIPTION
Some refactorings to the Processing module: the logic for preprocessors, postprocessors and bundle_processors were all similar and duplicated. Common functionality was extracted into methods, which are shared between preprocessors, postprocessors and bundle_processors.

It could be cleaned up further by moving common methods into its own class, i.e. a `ProcessorList` class with a `#register`, `#unregister` and an `[]` indexer. but you wouldnt want to change the public api (i.e. environment.postprocessors.unregister(...)) cause it would break the public api, but it may still clean up the class's internals. let me know if you guys want it, and I can add it to this pull request.
