### PR TITLE
Preserve line endings.

### DIFF
--- a/lib/sprockets/jst_processor.rb
+++ b/lib/sprockets/jst_processor.rb
@@ -18,9 +18,7 @@ module Sprockets
 
     def evaluate(scope, locals, &block)
       <<-JST
-(function() {
-  #{namespace} || (#{namespace} = {});
-  #{namespace}[#{scope.logical_path.inspect}] = #{indent(data)};
+(function() { #{namespace} || (#{namespace} = {}); #{namespace}[#{scope.logical_path.inspect}] = #{indent(data)};
 }).call(this);
       JST
     end


### PR DESCRIPTION
This patch is required so the line numbers in the debug console of your browser match up with the line endings in your template, if you use a template engine that supports line number preservation, like my fork of EJS.
