### PR TITLE
Create the environment instance after require dependencies

### DIFF
--- a/bin/sprockets
+++ b/bin/sprockets
@@ -12,12 +12,9 @@ unless ARGV.delete("--noenv")
 end
 
 filenames = []
-environment = Sprockets::Environment.new(Dir.pwd)
 manifest = nil
-
-(ENV['SPROCKETS_PATH'] || "").split(File::PATH_SEPARATOR).each do |path|
-  environment.append_path path
-end
+includes = []
+output_dir = ''
 
 OptionParser.new do |opts|
   opts.summary_width = 28
@@ -33,11 +30,11 @@ OptionParser.new do |opts|
   end
 
   opts.on("-I DIRECTORY", "--include=DIRECTORY", "Adds the directory to the Sprockets load path") do |directory|
-    environment.append_path directory
+    includes << directory
   end
 
   opts.on("-o DIRECTORY", "--output=DIRECTORY", "Copy provided assets into DIRECTORY") do |directory|
-    manifest = Sprockets::Manifest.new(environment, directory)
+    output_dir = directory
   end
 
   opts.on("--noenv", "Disables .sprocketsrc file") do
@@ -64,13 +61,22 @@ OptionParser.new do |opts|
   end
 end
 
+environment = Sprockets::Environment.new(Dir.pwd)
+
+includes.each { |directory| environment.append_path directory }
+
+(ENV['SPROCKETS_PATH'] || "").split(File::PATH_SEPARATOR).each do |path|
+  environment.append_path path
+end
+
 if environment.paths.empty?
   warn "No load paths given"
   warn "Usage: sprockets -Ijavascripts/ filename"
   exit 1
 end
 
-if manifest
+if !output_dir.empty?
+  manifest = Sprockets::Manifest.new(environment, output_dir)
   manifest.compile(filenames)
 elsif filenames.length == 1
   puts environment.find_asset(filenames.first).to_s


### PR DESCRIPTION
I'm using the hamljs template engine with this gem https://github.com/dharanasoft/haml-sprockets, when I tried to compile my assets, the templates were not being interpreted with the hamljs engine, I realized it happens because the environment instance was being created before require the dependencies, so I moved the environment instance just after the options parsing.
