### PR TITLE
Remove redundant file.close

### DIFF
--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -153,7 +153,6 @@ module Sprockets
         else
           # Write out as is
           f.write to_s
-          f.close
         end
       end
 


### PR DESCRIPTION
While profiling "assets:precompile" under JRuby, I came across this call to `File#close` that is redundant but results in an exception under the hood.  Getting Java stack trace data is somewhat slow in JRuby, so this is a performance issue.

I successfully ran the unit tests with `rake test` using JRuby 1.7.0 in 1.8.7 compatibility mode.
