### PR TITLE
Consistent scope for Sass::Script::Functions

### DIFF
--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -11,7 +11,7 @@ module Sprockets
 
     def self.engine_initialized?
       defined?(::Sass::Engine) && defined?(::Sass::Script::Functions) &&
-        Sass::Script::Functions < Sprockets::SassFunctions
+        ::Sass::Script::Functions < Sprockets::SassFunctions
     end
 
     def initialize_engine
@@ -23,7 +23,7 @@ module Sprockets
       # Install custom functions. It'd be great if this didn't need to
       # be installed globally, but could be passed into Engine as an
       # option.
-      Sass::Script::Functions.send :include, Sprockets::SassFunctions
+      ::Sass::Script::Functions.send :include, Sprockets::SassFunctions
     end
 
     def prepare


### PR DESCRIPTION
In the `SassTemplate` initializer, always use top-level scope for `::Sass::Script::Functions`.

This adds consistency and fixes issues with Rails 4, which manages to define `Sprockets::Sass` somewhere in its standard dependencies.
