### PR TITLE
Set default mime type using acessor in jst processor

### DIFF
--- a/lib/sprockets/jst_processor.rb
+++ b/lib/sprockets/jst_processor.rb
@@ -2,9 +2,7 @@ require 'tilt'
 
 module Sprockets
   class JstProcessor < Tilt::Template
-    def self.default_mime_type
-      'application/javascript'
-    end
+    self.default_mime_type = 'application/javascript'
 
     def self.default_namespace
       'this.JST'


### PR DESCRIPTION
Small refactor in Jst Processor to set the default mime type using the accessor, similar to all other processors.
