### PR TITLE
Ensure we get the top level Sass

### DIFF
--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -16,7 +16,7 @@ module Sprockets
     end
 
     def evaluate(context, locals, &block)
-      Sass::Engine.new(data, {
+      ::Sass::Engine.new(data, {
         :syntax => :scss,
         :cache => false,
         :read_cache => false,


### PR DESCRIPTION
If using sprockets-sass this resolves to Sprockets::Sass::Engine which isn't defined.
