### PR TITLE
add license information to the gemspec

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.version = Sprockets::VERSION
   s.summary = "Rack-based asset packaging system"
   s.description = "Sprockets is a Rack-based asset packaging system that concatenates and serves JavaScript, CoffeeScript, CSS, LESS, Sass, and SCSS."
+  s.license = "MIT"
 
   s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
   s.executables = ["sprockets"]


### PR DESCRIPTION
this way it can be used with rubygems.org API
