### PR TITLE
Move asset Gzip compression to Sprockets to fix Rails 4 regression

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -132,6 +132,7 @@ module Sprockets
           else
             logger.info "Writing #{target}"
             asset.write_to target
+            asset.write_to "#{target}.gz" if target =~ /\.(js|css)$/
           end
 
           save
@@ -147,6 +148,7 @@ module Sprockets
     #
     def remove(filename)
       path = File.join(dir, filename)
+      gzip = "#{path}.gz"
       logical_path = files[filename]['logical_path']
 
       if assets[logical_path] == filename
@@ -155,6 +157,7 @@ module Sprockets
 
       files.delete(filename)
       FileUtils.rm(path) if File.exist?(path)
+      FileUtils.rm(gzip) if File.exist?(gzip)
 
       save
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -154,6 +154,18 @@ class TestManifest < Sprockets::TestCase
     assert_equal gallery_digest_path, data['assets']['gallery.css']
   end
 
+  test "compress assets" do
+    gallery_digest_path = @env['gallery.css'].digest_path
+    app_digest_path = @env['application.js'].digest_path
+    img_digest_path = @env['blank.gif'].digest_path
+
+    @manifest.compile('gallery.css', 'application.js', 'blank.gif')
+
+    assert File.exist?("#{@dir}/#{gallery_digest_path}.gz")
+    assert File.exist?("#{@dir}/#{app_digest_path}.gz")
+    assert !File.exist?("#{@dir}/#{img_digest_path}.gz")
+  end
+
   test "recompile asset" do
     digest_path = @env['application.js'].digest_path
     filename = fixture_path('default/application.js.coffee')
@@ -193,6 +205,7 @@ class TestManifest < Sprockets::TestCase
 
     @manifest.compile('application.js')
     assert File.exist?("#{@dir}/#{digest_path}")
+    assert File.exist?("#{@dir}/#{digest_path}.gz")
 
     data = JSON.parse(File.read(@manifest.path))
     assert data['files'][digest_path]
@@ -201,6 +214,7 @@ class TestManifest < Sprockets::TestCase
     @manifest.remove(digest_path)
 
     assert !File.exist?("#{@dir}/#{digest_path}")
+    assert !File.exist?("#{@dir}/#{digest_path}.gz")
 
     data = JSON.parse(File.read(@manifest.path))
     assert !data['files'][digest_path]


### PR DESCRIPTION
Rails 4 forget to compress assets to `.gz`: https://github.com/rails/sprockets-rails/issues/37.

Rails 3 [compress assets](https://github.com/rails/rails/blob/3-2-stable/actionpack/lib/sprockets/static_compiler.rb#L40) in its `StaticCompiler`, but `sprockets-rails` doesn’t contain `StaticCompiler`, so there is no compression in Rails 4.

I move old `.gz` compression code from Rails 3 directly to Sprockets (instead of Sprockets Rails), because it’s very useful feature and don’t depend on environment (we need `.gz` compression also in Sinatra or in just static site compile like jekyll).
