### PR TITLE
Make the DirectiveProcessor encoding aware

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -92,6 +92,8 @@ module Sprockets
       @context = context
 
       @result = ""
+      @result.force_encoding(body.encoding) if body.respond_to?(:encoding)
+
       @has_written_body = false
 
       process_directives

--- a/test/fixtures/context/utf8.js.erb
+++ b/test/fixtures/context/utf8.js.erb
@@ -1,0 +1,1 @@
+console.log("Snowman: <%= "\xe2\x98\x83" %>")

--- a/test/test_directive_processor.rb
+++ b/test/test_directive_processor.rb
@@ -108,6 +108,19 @@ class DirectiveProcessorTest < Sprockets::TestCase
   end
 end
 
+if "".respond_to?(:encoding)
+  class TestDirectiveProcessorEncoding < Sprockets::TestCase
+    def setup
+      @env = Sprockets::Environment.new
+      @env.append_path(fixture_path('context'))
+    end
+
+    test "encoding of evaluated string" do
+      assert_equal Encoding::UTF_8, @env['utf8.js'].source.encoding
+    end
+  end
+end
+
 class TestCustomDirectiveProcessor < Sprockets::TestCase
   def setup
     @env = Sprockets::Environment.new


### PR DESCRIPTION
In Ruby 1.9, the directive_processor.rb source file defaults to US-ASCII
as it doesn't contain a magic comment, meaning the String initialised in
`@result` gets a US-ASCII encoding.

This means that when content is concatenated onto `@result` (e.g. in
process_source), Ruby will maintain the US-ASCII encoding, provided the
content being concatenated contains no non-ascii chars.

The changes in this commit force the encoding of the resulting string to
be that of the body, because conceptually that is the string we are
"concatenating" with.

The test I have added is quite high level (i.e. it doens't refer directly to the directive processor), but it fails with "invalid byte sequnce" without it, so I assume it is testing the change I have made :wink:
