### PR TITLE
Change rack session options only when asset is found

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -25,11 +25,6 @@ module Sprockets
 
       msg = "Served asset #{env['PATH_INFO']} -"
 
-      # Mark session as "skipped" so no `Set-Cookie` header is set
-      env['rack.session.options'] ||= {}
-      env['rack.session.options'][:defer] = true
-      env['rack.session.options'][:skip] = true
-
       # Extract the path from everything after the leading slash
       path = unescape(env['PATH_INFO'].to_s.sub(/^\//, ''))
 
@@ -45,6 +40,8 @@ module Sprockets
 
       # Look up the asset.
       asset = find_asset(path, :bundle => !body_only?(env))
+      # Do not change session options when pass the request to other routes.
+      skip_session(env) unless asset.nil?
 
       # `find_asset` returns nil if the asset doesn't exist
       if asset.nil?
@@ -242,6 +239,13 @@ module Sprockets
       # Helper to quote the assets digest for use as an ETag.
       def etag(asset)
         %("#{asset.digest}")
+      end
+
+      # Mark session as "skipped" so no `Set-Cookie` header is set
+      def skip_session(env)
+        env['rack.session.options'] ||= {}
+        env['rack.session.options'][:defer] = true
+        env['rack.session.options'][:skip] = true
       end
   end
 end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -76,6 +76,13 @@ class TestServer < Sprockets::TestCase
       last_response.headers['ETag']
   end
 
+  test "serve source with session skipped" do
+    rack_env = { 'PATH_INFO' => "application.js" }
+    @env.call(rack_env)
+    assert_equal true, rack_env['rack.session.options'][:skip]
+    assert_equal true, rack_env['rack.session.options'][:defer]
+  end
+
   test "updated file updates the last modified header" do
     time = Time.now
     path = fixture_path "server/app/javascripts/foo.js"
@@ -165,6 +172,12 @@ class TestServer < Sprockets::TestCase
     assert_equal "pass", last_response.headers['X-Cascade']
   end
 
+  test "missing source does not touch env" do
+    rack_env = { 'PATH_INFO' => "none.js" }
+    @env.call(rack_env)
+    assert_equal nil, rack_env['rack.session.options']
+  end
+  
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
     assert_equal 200, last_response.status


### PR DESCRIPTION
If asset is not found, <del>Rack</del><ins>Rails</ins> will try next route since `X-Cascade` header
is set. It is better do not change env when the request is pass through.

[sporkd/asset_prefix_test](https://github.com/sporkd/asset_prefix_test)
has demonstrated that when assets prefix is also a prefix of controller
routes, the session is never stored.
