### PR TITLE
Use explict, secure url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
Using :rubygems is deprecated
