### PR TITLE
More meaningful error message when .erb extension is forgotten

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -279,7 +279,8 @@ Extend your environment context with a custom method.
         location << ":#{@__LINE__}" if @__LINE__
 
         exception.extend(Sprockets::EngineError)
-        exception.sprockets_annotation = "  (in #{location})"
+        exception.sprockets_annotation ||= ''
+        exception.sprockets_annotation << "  (in #{location})"
       end
 
       def logger

--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -51,10 +51,26 @@ module Sprockets
       }
 
       ::Sass::Engine.new(data, options).render
-    rescue ::Sass::SyntaxError => e
-      # Annotates exception message with parse line number
-      context.__LINE__ = e.sass_backtrace.first[:line]
-      raise e
+    rescue ::Sass::SyntaxError => exception
+      # Annotates exception message with erb comment if applies, and with
+      # parse line number
+      annotate_exception!(exception, context.pathname)
+      context.__LINE__ = exception.sass_backtrace.first[:line]
+      raise exception
+    end
+
+    def annotate_exception!(exception, pathname)
+      return false unless missing_erb_extension?(pathname)
+      exception.extend(Sprockets::EngineError)
+      exception.sprockets_annotation = "You are using erb in your file: " +
+        "#{pathname} but have not added the .erb extension.\n" +
+        "Please change the file name to #{pathname}.erb and try again."
+    end
+
+    def missing_erb_extension?(pathname)
+      erb_extension = pathname.to_s.split('/').last.match(/erb\Z/)
+      has_erb_tags = File.read(pathname) =~ /<%=?(.+)%>/
+      !erb_extension && has_erb_tags
     end
   end
 end

--- a/test/fixtures/asset/erb_without_extension.coffee
+++ b/test/fixtures/asset/erb_without_extension.coffee
@@ -1,0 +1,1 @@
+<%= 'CoffeeScript' %>

--- a/test/fixtures/asset/erb_without_extension.less
+++ b/test/fixtures/asset/erb_without_extension.less
@@ -1,0 +1,3 @@
+body {
+  background: <%= 'red' %>;
+}

--- a/test/fixtures/asset/erb_without_extension.scss
+++ b/test/fixtures/asset/erb_without_extension.scss
@@ -1,0 +1,3 @@
+body {
+  background: <%= 'red' %>;
+}

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -707,6 +707,13 @@ class BundledAssetTest < Sprockets::TestCase
     end
   end
 
+  test "SCSS file to be processed by ERB without erb extension raises exception" do
+    exception = assert_raise Sprockets::EngineError do
+      asset("erb_without_extension.scss").to_s
+    end
+    assert exception.message =~ /but have not added the .erb extension./, "'#{exception.message}' didn't say 'missing erb extension'"
+  end
+
   test "require_directory requires all child files in alphabetical order" do
     assert_equal(
       "ok(\"b.js.erb\");\n",


### PR DESCRIPTION
If now we use erb tags but don't add erb extension to the file name,
error message is quite obscure:

```
Invalid CSS after "...und-image: url(": expected ")", was "<%= asset_path ..."
```

This raises a more meaningful message like:

```
You are using erb in your file: #{filename} but have not added a .erb extension.
```

Related notes: https://gist.github.com/schneems/5249586
