### PR TITLE
Log when creating Gzipped assets

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -132,7 +132,10 @@ module Sprockets
           else
             logger.info "Writing #{target}"
             asset.write_to target
-            asset.write_to "#{target}.gz" if asset.is_a?(BundledAsset)
+            if asset.is_a?(BundledAsset)
+              logger.info "Writing #{target}.gz"
+              asset.write_to "#{target}.gz"
+            end
           end
 
           save


### PR DESCRIPTION
Fixes bug when writing a gzipped file and no log message was output.
