### PR TITLE
Return the raw contents of an asset when `?raw=1` is appended to the end of the URL.

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -53,6 +53,12 @@ module Sprockets
         # Return a 404 Not Found
         not_found_response
 
+      elsif raw?(env)
+        logger.info "#{msg} 200 OK (#{time_elapsed.call}ms)"
+
+        # Return a 200 with the asset's raw contents
+        raw_ok_response(asset, env)
+
       # Check request headers `HTTP_IF_NONE_MATCH` against the asset digest
       elsif etag_match?(asset, env)
         logger.info "#{msg} 304 Not Modified (#{time_elapsed.call}ms)"
@@ -183,6 +189,11 @@ module Sprockets
         env["QUERY_STRING"].to_s =~ /body=(1|t)/
       end
 
+      # Test if `?raw=1` or `raw=true` query param is set
+      def raw?(env)
+        env["QUERY_STRING"].to_s =~ /raw=(1|t)/
+      end
+
       # Returns a 304 Not Modified response tuple
       def not_modified_response(asset, env)
         [ 304, {}, [] ]
@@ -191,6 +202,11 @@ module Sprockets
       # Returns a 200 OK response tuple
       def ok_response(asset, env)
         [ 200, headers(env, asset, asset.length), asset ]
+      end
+
+      # Returns a 200 OK response tuple
+      def raw_ok_response(asset, env)
+        [ 200, headers(env, asset, asset.raw_length), asset.raw_source ]
       end
 
       def headers(env, asset, length)

--- a/lib/sprockets/static_asset.rb
+++ b/lib/sprockets/static_asset.rb
@@ -9,8 +9,7 @@ module Sprockets
   class StaticAsset < Asset
     # Returns file contents as its `source`.
     def source
-      # File is read everytime to avoid memory bloat of large binary files
-      pathname.open('rb') { |f| f.read }
+      raw_source
     end
 
     # Implemented for Rack SendFile support.

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -44,6 +44,20 @@ class TestServer < Sprockets::TestCase
     assert_equal "9", last_response.headers['Content-Length']
   end
 
+  test "serve raw source" do
+    contents = <<-eos
+// =require "foo"
+
+(function() {
+  application.boot();
+})();
+eos
+
+    get "/assets/application.js?raw=1"
+    assert_equal 200, last_response.status
+    assert_equal contents, last_response.body
+  end
+
   test "serve single source file from indexed environment" do
     get "/cached/javascripts/foo.js"
     assert_equal "var foo;\n", last_response.body


### PR DESCRIPTION
This is useful for quick debugging when you don't have a your text editor/environment ready to view the source of a specific asset URL.
