### PR TITLE
add depend_on_asset directive description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,11 @@ source file before any subsequent `require` or `include` directives.
 including it in the bundle. This is useful when you need to expire an
 asset's cache in response to a change in another file.
 
+### The `depend_on_asset` Directive ###
+
+`depend_on_asset` *path* works like `depend_on`, but operates
+recursively reading the the file and following the directives found.
+
 ### The `stub` Directive ###
 
 `stub` *path* allows dependency to be excluded from the asset bundle.


### PR DESCRIPTION
#122

This feature is being very useful in one of my projects and i found it diving in the source code. I think it would be nice to have it visible in the documentation so I documented in the README file.

Please feel free to change the text if something can be explained better. English is not my mother tongue

Thanks a lot for your effort in this gem. It is great :)
