### PR TITLE
Two small docfixes in Sprockets::Processing

### DIFF
--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -161,7 +161,7 @@ module Sprockets
     #
     # A block can be passed for to create a shorthand processor.
     #
-    #     register_bundle_processor :my_processor do |context, data|
+    #     register_bundle_processor 'text/css', :my_processor do |context, data|
     #       data.gsub(...)
     #     end
     #

--- a/lib/sprockets/processor.rb
+++ b/lib/sprockets/processor.rb
@@ -3,7 +3,7 @@ require 'tilt'
 module Sprockets
   # `Processor` creates an anonymous processor class from a block.
   #
-  #     register_preprocessor :my_processor do |context, data|
+  #     register_preprocessor 'text/css', :my_processor do |context, data|
   #       # ...
   #     end
   #


### PR DESCRIPTION
Update examples in the docs for 2 methods in order to avoid an `ArgumentError` for people using them.
