### PR TITLE
Possible optimization: caching AssetAttributes per Asset in the Index

### DIFF
--- a/lib/sprockets/index.rb
+++ b/lib/sprockets/index.rb
@@ -35,6 +35,7 @@ module Sprockets
 
       # Initialize caches
       @assets  = {}
+      @asset_attributes = {}
       @digests = {}
     end
 
@@ -72,6 +73,10 @@ module Sprockets
 
         asset
       end
+    end
+
+    def attributes_for(path)
+      @asset_attributes[path] ||= super
     end
 
     protected

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -45,6 +45,16 @@ class TestCaching < Sprockets::TestCase
     assert asset2.equal?(asset1)
   end
 
+  test "same index asset attributes are equal" do
+    index = @env1.index
+
+    asset_attributes1 = index.attributes_for('gallery.js')
+    asset_attributes2 = index.attributes_for('gallery.js')
+
+    assert asset_attributes1.equal?(asset_attributes2)
+    assert asset_attributes2.equal?(asset_attributes1)
+  end
+
   test "same environment instance is cached at logical and expanded path" do
     env = @env1
 


### PR DESCRIPTION
This caches the result of `Index#attributes_for(path)` by keeping a cache per asset (per index).
### why?

I recently realized that `AssetAttributes#content_type`, although memoized, gets recalculated multiple times for the same path because by default `Index#attributes_for(path)` creates a new `AssetAttributes` object every time you call it. 

If we can keep a hash that maps a pathname to its `AssetAttributes`, we could avoid this lookup. 

It also seemed logical that we should keep this cache in `Index` since it's supposed be a cached `Environment`.
### will it work?

I'm new to the sprockets codebase & unaware of any pitfalls with this patch. Could there be a change to an asset  from the first time `attributes_for` is called with it until the next time it's called?
### boost?

In a Rails 3.2 app with a lot of sass/js/images/fonts files, this speeds up `assets:precompile` by ~8%. I'm not sure how conventional my environment is though -- does anyone else want to benchmark `asset:precompile` with this patch too?
