### PR TITLE
Allow Setting Keep via Env Var

### DIFF
--- a/lib/rake/sprocketstask.rb
+++ b/lib/rake/sprocketstask.rb
@@ -100,7 +100,7 @@ module Rake
       @manifest     = lambda { Sprockets::Manifest.new(index, output) }
       @logger       = Logger.new($stderr)
       @logger.level = Logger::INFO
-      @keep         = 2
+      @keep         = Sprockets::CLEAN_KEEP
 
       yield self if block_given?
 

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -1,6 +1,7 @@
 require 'sprockets/version'
 
 module Sprockets
+  CLEAN_KEEP = Integer(ENV['SPROCKETS_CLEAN_KEEP'] || 2)
   # Environment
   autoload :Base,                    "sprockets/base"
   autoload :Environment,             "sprockets/environment"

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -168,7 +168,7 @@ module Sprockets
 
     # Cleanup old assets in the compile directory. By default it will
     # keep the latest version plus 2 backups.
-    def clean(keep = 2)
+    def clean(keep = Sprockets::CLEAN_KEEP)
       self.assets.keys.each do |logical_path|
         # Get assets sorted by ctime, newest first
         assets = backups_for(logical_path)


### PR DESCRIPTION
Right now the keep value in sprockets is a magic number of 2. This PR moves that number to a constant that can be used across multiple files and modified globally. This PR also allows the manipulation of this value from the command line or other processes via an environment variable. This would be extremely useful for running command from terminal. For example to run clean and keep only one backup you could run a rake task like this:

``` sh
SPROCKETS_CLEAN_KEEP=1 rake assets:clean
```

Assuming the user was also using the sprockets-rails tasks.
