### PR TITLE
Gzips svg assets and creates a new file with svgz extension

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -133,6 +133,7 @@ module Sprockets
             logger.info "Writing #{target}"
             asset.write_to target
             asset.write_to "#{target}.gz" if asset.is_a?(BundledAsset)
+            asset.write_to "#{target}z" if File.extname(target) == '.svg'
           end
 
           save

--- a/lib/sprockets/static_asset.rb
+++ b/lib/sprockets/static_asset.rb
@@ -21,7 +21,7 @@ module Sprockets
     # Save asset to disk.
     def write_to(filename, options = {})
       # Gzip contents if filename has '.gz'
-      options[:compress] ||= File.extname(filename) == '.gz'
+      options[:compress] ||= File.extname(filename).match(/\.(sv)?gz/)
 
       FileUtils.mkdir_p File.dirname(filename)
 


### PR DESCRIPTION
Since SVG images are essentially XML, they could benefit greatly from Gzip compression resulting is over 80% compression.

This pull request allows for the Gzip of SVG files and saves them with the .svgz extension, as per convention. This is different from the usual .gz extension used in .css and .js files.

The original file is also retained of course.
