### PR TITLE
Remove Deleted Assets On Clean

### DIFF
--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -247,6 +247,26 @@ class TestManifest < Sprockets::TestCase
     end
   end
 
+  test "remove deleted files" do
+    digest_path = @env['application.js'].digest_path
+    filename = fixture_path('default/application.js.coffee')
+
+    sandbox filename do
+      @manifest.compile('application.js')
+      file = "#{@dir}/#{digest_path}"
+      assert File.exist?(file)
+      FileUtils.rm_r(filename)
+      assert !File.exist?(filename)
+
+      @manifest.compile('application.js')
+      assert File.exist?(file)
+
+      @manifest.clean(0)
+
+      assert !File.exist?(file)
+    end
+  end
+
   test "remove old backups" do
     digest_path = @env['application.js'].digest_path
     filename = fixture_path('default/application.js.coffee')


### PR DESCRIPTION
Right now sprockets will preserve the last number copies of an asset after it is modified, lets call this `keep`. If clean is called `X` more times than `keep` is specified and there are more than `keep` copies, then `X` backups will be removed from the file system. This behavior has two desirable behaviors: allowing for rolling deploys since we may need to render old assets from the new server on deploy, and preventing the compiled asset directory from growing continuously.

Right now if a user deletes an asset, it will not be removed from the compiled directory regardless of how many times compile or clean are called. If a developer needs to delete files frequently, this means that the compiled directory will only continue to grow in size even if clean is being called. A user may need to delete an asset due to security concerns: 
heroku/heroku-buildpack-ruby#123 and it is currently impossible without resorting to a hack.

This PR allows sprockets to remove files from the compiled directory that have been deleted from the source directory. To do this we need to tag each asset with a `compiled_at` time and store a global `compiled_at` time to know the last time compile was run. Instead of being deleted instantaneously, removed assets are stored in a `deleted_assets` key in the top level manifest. Every time `clean` is run it will increment a `generation` in the asset. When `generation` == `keep` then the asset will be removed from the project. This allows us to preserve rolling deploy functionality for deleted assets, while not allowing the deleted assets to continue to take up an ever increasing amount of space.

ATP
