### PR TITLE
Update Travis Ruby Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs
 pkg
 tmp
 *.rbc
+*.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby
-  - ree
+  - jruby-19mode
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+*   Sprockets minimum Ruby version increased to 1.9.3
+
+    *Richard Schneeman*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ It features declarative dependency management for JavaScript and CSS
 assets, as well as a powerful preprocessor pipeline that allows you to
 write assets in languages like CoffeeScript, Sass, SCSS and LESS.
 
+[![Build Status](https://travis-ci.org/sstephenson/sprockets.png)](https://travis-ci.org/sstephenson/sprockets)
+
 # Installation #
 
 Install Sprockets from RubyGems:

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |s|
   s.email = ["sstephenson@gmail.com", "josh@joshpeek.com"]
   s.homepage = "http://getsprockets.org/"
   s.rubyforge_project = "sprockets"
+
+  s.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
Remove Ruby 1.8.7 & REE: officially EOL
Remove Ruby 1.9.2: unmaintained

Only test JRuby in 1.9 mode
