### PR TITLE
Refactor redundant code

### DIFF
--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -67,15 +67,7 @@ module Sprockets
 
     # Cache `find_asset` calls
     def find_asset(path, options = {})
-      options[:bundle] = true unless options.key?(:bundle)
-
-      # Ensure inmemory cached assets are still fresh on every lookup
-      if (asset = @assets[cache_key_for(path, options)]) && asset.fresh?(self)
-        asset
-      elsif asset = index.find_asset(path, options)
-        # Cache is pushed upstream by Index#find_asset
-        asset
-      end
+      index.find_asset(path, options)
     end
 
     protected

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -28,8 +28,8 @@ class TestCaching < Sprockets::TestCase
     assert asset1
     assert asset2
 
-    assert asset1.equal?(asset2)
-    assert asset2.equal?(asset1)
+    assert_equal asset1, asset2
+    assert_equal asset2, asset1
   end
 
   test "same index instance cache objects are equal" do
@@ -54,8 +54,8 @@ class TestCaching < Sprockets::TestCase
     assert asset1
     assert asset2
 
-    assert asset1.equal?(asset2)
-    assert asset2.equal?(asset1)
+    assert_equal asset1, asset2
+    assert_equal asset2, asset1
   end
 
   test "same index instance is cached at logical and expanded path" do
@@ -97,8 +97,8 @@ class TestCaching < Sprockets::TestCase
     child2 = env.find_asset(child1.pathname, :bundle => false)
     assert child2
 
-    assert child1.equal?(child2)
-    assert child2.equal?(child1)
+    assert_equal child1, child2
+    assert_equal child2, child1
   end
 
   test "proccessed and bundled assets are cached separately" do

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -147,7 +147,7 @@ class TestServer < Sprockets::TestCase
     asset_after = @env["application.js"]
     assert asset_after
 
-    assert asset_before.equal?(asset_after)
+    assert_equal asset_before, asset_after
   end
 
   test "fingerprint digest sets expiration to the future" do


### PR DESCRIPTION
In `environment.rb` we check to see if an asset is in the cache and if it is fresh:

``` ruby
(asset = @assets[cache_key_for(path, options)]) && asset.fresh?(self)
```

If the asset exists but is not fresh it hits `index.find_asset(path, options)`. Inside of `Index#find_asset` we return a cached asset if it exists:

``` ruby
if asset = @assets[cache_key_for(path, options)]
  asset
```

So if the asset is cached (at all, regardless of freshness) it will be returned. Otherwise it will hit the edge case inside of `Index#find_asset`

This code is identical in behavior to the previous code, but only incurs 1 cache check instead of 2 in worst case scenario and we never have to check for `fresh?`.

ATP
