### PR TITLE
replace `JSON` `dump`/`load` with `parse`/`generate`

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -434,7 +434,7 @@ module Sprockets
       end
 
       def json_decode(obj)
-        JSON.load(obj)
+        JSON.parse(obj, create_additions: false)
       end
   end
 end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -225,11 +225,11 @@ module Sprockets
     private
 
       def json_decode(obj)
-        JSON.load(obj)
+        JSON.parse(obj, create_additions: false)
       end
 
       def json_encode(obj)
-        JSON.dump(obj)
+        JSON.generate(obj)
       end
 
       def logger


### PR DESCRIPTION
`dump` and `load` are for built around Marshaling ruby objects generally.
They correspond with those methods on Ruby's `Marshal` class. Theses
methods actually call `parse`/`generate` in code but pass some defaults
along with it. Sprockets only needs to parse JSON documents not Ruby
objects.

For `JSON.load`, we want to disable `create_additions`.
`create_additions` could be considered a security hazard if set to true.
`create_additions` allows the instantiation of any class that's
marshaled as json
