### PR TITLE
add package.json to search path for packages that do not use bower.json

### DIFF
--- a/lib/sprockets/asset_attributes.rb
+++ b/lib/sprockets/asset_attributes.rb
@@ -22,6 +22,7 @@ module Sprockets
       # optimization: bower.json can only be nested one level deep
       if !path_without_extensions.to_s.index('/')
         paths << path_without_extensions.join("bower.json").to_s
+        paths << path_without_extensions.join("package.json").to_s
         # DEPRECATED bower configuration file
         paths << path_without_extensions.join("component.json").to_s
       end

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -129,7 +129,7 @@ module Sprockets
         args = attributes_for(logical_path).search_paths + [options]
         @trail.find(*args) do |path|
           pathname = Pathname.new(path)
-          if %w( bower.json component.json ).include?(pathname.basename.to_s)
+          if %w( package.json bower.json component.json ).include?(pathname.basename.to_s)
             bower = json_decode(pathname.read)
             case bower['main']
             when String

--- a/test/test_asset_attributes.rb
+++ b/test/test_asset_attributes.rb
@@ -2,9 +2,9 @@ require 'sprockets_test'
 
 class TestAssetAttributes < Sprockets::TestCase
   test "search paths" do
-    assert_equal ["index.js", "index/bower.json", "index/component.json"],
+    assert_equal ["index.js", "index/bower.json", "index/package.json", "index/component.json"],
       pathname("index.js").search_paths
-    assert_equal ["foo.js", "foo/bower.json", "foo/component.json", "foo/index.js"],
+    assert_equal ["foo.js", "foo/bower.json", "foo/package.json", "foo/component.json", "foo/index.js"],
       pathname("foo.js").search_paths
     assert_equal ["foo/bar.js", "foo/bar/index.js"],
       pathname("foo/bar.js").search_paths


### PR DESCRIPTION
A lot of packages use `package.json` instead of `bower.json`, but AFAICT the basic setup is the same, with the main file indicated under `main`.

Maybe I'm missing something but it would seem useful to add package.json to the search path as I have here, to handle that case.
