### PR TITLE
EJS example should should use `this` to access template properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ template function to render the template as a string. The resulting
 string can then be inserted into the DOM.
 
     <!-- templates/hello.jst.ejs -->
-    <div>Hello, <span><%= name %></span>!</div>
+    <div>Hello, <span><%= this.name %></span>!</div>
 
     // application.js
     //= require templates/hello


### PR DESCRIPTION
Just tried following the templating example in the README with ECO and had to use `@` (i.e. `this` in EJS) to access the `name` property. Maybe this is a small oversight into the documentation?
