### PR TITLE
change `inject` to `each_with_object` because this isn't a reduction

### DIFF
--- a/lib/sprockets/engines.rb
+++ b/lib/sprockets/engines.rb
@@ -68,7 +68,7 @@ module Sprockets
     private
       def deep_copy_hash(hash)
         initial = Hash.new { |h, k| h[k] = [] }
-        hash.inject(initial) { |h, (k, a)| h[k] = a.dup; h }
+        hash.each_with_object(initial) { |(k, a),h| h[k] = a.dup }
       end
   end
 end


### PR DESCRIPTION
Each iteration doesn't depend on the result of the previous (this isn't a reduction), so we can use `each_with_object` and avoid passing each return value to the next iteration.
