### PR TITLE
use an adapter class to avoid runtime checks

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -96,6 +96,7 @@ module Sprockets
     def cache=(cache)
       expire_index!
       @cache = cache
+      @cache_adapter = make_cache_adapter(cache)
     end
 
     def prepend_path(path)

--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -51,6 +51,7 @@ module Sprockets
         @trail.append_extension(ext)
       end
 
+      self.cache = nil
       expire_index!
 
       yield self if block_given?

--- a/lib/sprockets/index.rb
+++ b/lib/sprockets/index.rb
@@ -22,6 +22,7 @@ module Sprockets
       @logger            = environment.logger
       @context_class     = environment.context_class
       @cache             = environment.cache
+      @cache_adapter     = environment.cache_adapter
       @trail             = environment.trail.index
       @digest            = environment.digest
       @digest_class      = environment.digest_class


### PR DESCRIPTION
We can speed up cache get and set by using a proxy adapter object.  Then
we only have to check for `respond_to?` once (rather than every get / set)
