### PR TITLE
sprockets requires ruby >= 1.9.3, so just use String#bytesize

### DIFF
--- a/lib/sprockets/processed_asset.rb
+++ b/lib/sprockets/processed_asset.rb
@@ -10,7 +10,7 @@ module Sprockets
 
       context = environment.context_class.new(environment, logical_path, pathname)
       @source = context.evaluate(pathname)
-      @length = Rack::Utils.bytesize(source)
+      @length = source.bytesize
       @digest = environment.digest.update(source).hexdigest
 
       build_required_assets(environment, context)


### PR DESCRIPTION
We don't need to depend on rack.  The [gemspec requires a ruby version >= 1.9.3](https://github.com/sstephenson/sprockets/blob/cfebc24c30ff447d4b82710f75336c54b8f5a2df/sprockets.gemspec#L39) so there is no reason to depend on [rack's implementation of bytesize](https://github.com/rack/rack/blob/df1506b0825a096514fcb3821563bf9e8fd52743/lib/rack/utils.rb#L331-L340).
