### PR TITLE
use a factory method to create a processor class

### DIFF
--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -70,15 +70,7 @@ module Sprockets
     #     end
     #
     def register_preprocessor(mime_type, klass, &block)
-      if block_given?
-        name  = klass.to_s
-        klass = Class.new(Processor) do
-          @name      = name
-          @processor = block
-        end
-      end
-
-      @preprocessors[mime_type].push(klass)
+      @preprocessors[mime_type].push(Processor.make_processor(klass, &block))
     end
 
     # Registers a new Postprocessor `klass` for `mime_type`.
@@ -92,15 +84,7 @@ module Sprockets
     #     end
     #
     def register_postprocessor(mime_type, klass, &block)
-      if block_given?
-        name  = klass.to_s
-        klass = Class.new(Processor) do
-          @name      = name
-          @processor = block
-        end
-      end
-
-      @postprocessors[mime_type].push(klass)
+      @postprocessors[mime_type].push(Processor.make_processor(klass, &block))
     end
 
     # Deprecated alias for `unregister_preprocessor`.
@@ -166,15 +150,7 @@ module Sprockets
     #     end
     #
     def register_bundle_processor(mime_type, klass, &block)
-      if block_given?
-        name  = klass.to_s
-        klass = Class.new(Processor) do
-          @name      = name
-          @processor = block
-        end
-      end
-
-      @bundle_processors[mime_type].push(klass)
+      @bundle_processors[mime_type].push(Processor.make_processor(klass, &block))
     end
 
     # Remove Bundle Processor `klass` for `mime_type`.

--- a/lib/sprockets/processor.rb
+++ b/lib/sprockets/processor.rb
@@ -8,6 +8,16 @@ module Sprockets
   #     end
   #
   class Processor < Tilt::Template
+    def self.make_processor(klass, &block) # :nodoc:
+      return klass unless block_given?
+
+      name  = klass.to_s
+      Class.new(Processor) do
+        @name      = name
+        @processor = block
+      end
+    end
+
     # `processor` is a lambda or block
     def self.processor
       @processor


### PR DESCRIPTION
Using a factory method lets us dry up the `Processing` module.
