### PR TITLE
Allow involved processor to change the cache key

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -383,7 +383,13 @@ module Sprockets
       end
 
       def cache_key_for(path, options)
-        "#{path}:#{options[:bundle] ? '1' : '0'}"
+        processors = attributes_for(path).processors
+        processors_key = processors.map do |p|
+          version = p.respond_to?(:version) ? p.version : '0'
+          "#{p.name}-#{version}"
+        end.join(':')
+
+        "#{path}:#{options[:bundle] ? '1' : '0'}:#{processors_key}"
       end
 
       def circular_call_protection(path)


### PR DESCRIPTION
While many processor can afford using cached assets as long as the sources didn't change some needs to invalidate all the caches between versions. 

E.g.: currently when [Opal](https://github.com/opal/opal-rails#gotchas) is upgraded and a file store is used the cache store folder must be removed (i.e. tmp/cache/assets under rails).

If it's conceptually ok I'll add tests

cc @adambeynon
