### PR TITLE
Update homepage

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.authors = ["Sam Stephenson", "Joshua Peek"]
   s.email = ["sstephenson@gmail.com", "josh@joshpeek.com"]
-  s.homepage = "http://getsprockets.org/"
+  s.homepage = "https://github.com/sstephenson/sprockets"
   s.rubyforge_project = "sprockets"
 
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
Current homepage points to an expired domain http://getsprockets.org

This PR updates it to point at the github repo instead.
