### PR TITLE
Check if individual asset matches filters

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -358,6 +358,10 @@ module Sprockets
         ">"
     end
 
+    def filtered?(asset, filters)
+      matches_filter(filters || [], asset.logical_path, asset.pathname.to_s)
+    end
+
     protected
       # Clear index after mutating state. Must be implemented by the subclass.
       def expire_index!

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -300,6 +300,23 @@ module EnvironmentTests
     assert !paths.include?("gallery.css")
   end
 
+  test "filtered?" do
+    asset = @env["with_data_uri.css"]
+    assert @env.filtered?(asset, [])
+    # regex
+    assert @env.filtered?(asset, [/.*/])
+    assert !@env.filtered?(asset, [/[^\s\S]/])
+    # call arity 1
+    assert @env.filtered?(asset, [Proc.new {|lp| true }])
+    assert !@env.filtered?(asset, [Proc.new {|lp| false }])
+    # call arity 2
+    assert @env.filtered?(asset, [Proc.new {|lp, f| true }])
+    assert !@env.filtered?(asset, [Proc.new {|lp, f| false }])
+    # file glob
+    assert @env.filtered?(asset, ["*.css"])
+    assert !@env.filtered?(asset, ["*.foo"])
+  end
+
   test "iterate over each logical path matching proc filters" do
     paths = []
     @env.each_logical_path(proc { |fn| File.extname(fn) == '.js' }) do |logical_path|


### PR DESCRIPTION
This PR exposes `matches_filter` via a public method called `filtered?` for the purposes of detecting if an asset exists in a filter. This is to be used in rails/sprockets-rails#96. This change to sprockets was requested by @rafaelfranca to prevent the interface from accidentally changing or breaking.
