### PR TITLE
exposing context to sass compressor fixing helper function calls

### DIFF
--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -20,7 +20,11 @@ module Sprockets
         :syntax => :scss,
         :cache => false,
         :read_cache => false,
-        :style => :compressed
+        :style => :compressed,
+        :sprockets => {
+          :context => context,
+          :environment => context.environment
+        }
       }).render
     end
   end


### PR DESCRIPTION
sass_functions.rb references the context from options[sprockets][context]

https://github.com/sstephenson/sprockets/blob/v2.10.0/lib/sprockets/sass_functions.rb#L63

This blows up when you try to run code that calls these helper functions through the sass compressor because it instantiates the sass engine without the context options.  This doesn't happen when running without the compressor because the sass_template provides this option already.

https://github.com/sstephenson/sprockets/blob/v2.10.0/lib/sprockets/sass_template.rb#L47
