### PR TITLE
Avoid defining Sprockets Sass Functions globally

### DIFF
--- a/lib/sprockets/sass_functions.rb
+++ b/lib/sprockets/sass_functions.rb
@@ -2,69 +2,90 @@ require 'sass'
 
 module Sprockets
   module SassFunctions
-    def asset_path(path)
-      Sass::Script::String.new(sprockets_context.asset_path(path.value), :string)
-    end
+    def self.define_functions(obj)
+      obj.class_eval do
+        def asset_path(path)
+          Sass::Script::String.new(sprockets_context.asset_path(path.value), :string)
+        end
 
-    def asset_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.asset_path(path.value) + ")")
-    end
+        def asset_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.asset_path(path.value) + ")")
+        end
 
-    def image_path(path)
-      Sass::Script::String.new(sprockets_context.image_path(path.value), :string)
-    end
+        def image_path(path)
+          Sass::Script::String.new(sprockets_context.image_path(path.value), :string)
+        end
 
-    def image_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.image_path(path.value) + ")")
-    end
+        def image_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.image_path(path.value) + ")")
+        end
 
-    def video_path(path)
-      Sass::Script::String.new(sprockets_context.video_path(path.value), :string)
-    end
+        def video_path(path)
+          Sass::Script::String.new(sprockets_context.video_path(path.value), :string)
+        end
 
-    def video_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.video_path(path.value) + ")")
-    end
+        def video_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.video_path(path.value) + ")")
+        end
 
-    def audio_path(path)
-      Sass::Script::String.new(sprockets_context.audio_path(path.value), :string)
-    end
+        def audio_path(path)
+          Sass::Script::String.new(sprockets_context.audio_path(path.value), :string)
+        end
 
-    def audio_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.audio_path(path.value) + ")")
-    end
+        def audio_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.audio_path(path.value) + ")")
+        end
 
-    def font_path(path)
-      Sass::Script::String.new(sprockets_context.font_path(path.value), :string)
-    end
+        def font_path(path)
+          Sass::Script::String.new(sprockets_context.font_path(path.value), :string)
+        end
 
-    def font_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.font_path(path.value) + ")")
-    end
+        def font_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.font_path(path.value) + ")")
+        end
 
-    def javascript_path(path)
-      Sass::Script::String.new(sprockets_context.javascript_path(path.value), :string)
-    end
+        def javascript_path(path)
+          Sass::Script::String.new(sprockets_context.javascript_path(path.value), :string)
+        end
 
-    def javascript_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.javascript_path(path.value) + ")")
-    end
+        def javascript_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.javascript_path(path.value) + ")")
+        end
 
-    def stylesheet_path(path)
-      Sass::Script::String.new(sprockets_context.stylesheet_path(path.value), :string)
-    end
+        def stylesheet_path(path)
+          Sass::Script::String.new(sprockets_context.stylesheet_path(path.value), :string)
+        end
 
-    def stylesheet_url(path)
-      Sass::Script::String.new("url(" + sprockets_context.stylesheet_path(path.value) + ")")
-    end
+        def stylesheet_url(path)
+          Sass::Script::String.new("url(" + sprockets_context.stylesheet_path(path.value) + ")")
+        end
 
-    protected
-      def sprockets_context
-        options[:sprockets][:context]
+        protected
+          def sprockets_context
+            options[:sprockets][:context]
+          end
+
+          def sprockets_environment
+            options[:sprockets][:environment]
+          end
       end
 
-      def sprockets_environment
-        options[:sprockets][:environment]
+      if block_given?
+        begin
+          yield
+        ensure
+          obj.class_eval do
+            remove_method :asset_path, :asset_url,
+              :image_path, :image_url,
+              :video_path, :video_url,
+              :audio_path, :audio_url,
+              :font_path, :font_url,
+              :javascript_path, :javascript_url,
+              :stylesheet_path, :stylesheet_url,
+              :sprockets_context, :sprockets_environment
+          end
+        end
       end
+    end
   end
 end

--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -12,13 +12,6 @@ module Sprockets
     def render(context)
       require 'sass' unless defined? ::Sass
 
-      unless ::Sass::Script::Functions < Sprockets::SassFunctions
-        # Install custom functions. It'd be great if this didn't need to
-        # be installed globally, but could be passed into Engine as an
-        # option.
-        ::Sass::Script::Functions.send :include, Sprockets::SassFunctions
-      end
-
       # Use custom importer that knows about Sprockets Caching
       cache_store = SassCacheStore.new(context.environment)
 
@@ -33,8 +26,11 @@ module Sprockets
         }
       }
 
-      engine = ::Sass::Engine.new(data, options)
-      css = engine.render
+      engine, css = nil, nil
+      Sprockets::SassFunctions.define_functions(::Sass::Script::Functions) do
+        engine = ::Sass::Engine.new(data, options)
+        css = engine.render
+      end
 
       # Track all imported files
       engine.dependencies.each do |dependency|


### PR DESCRIPTION
Injecting functions directly into `::Sass::Script::Functions` is dangerous since its global and effects other `Sass::Engine` invocations that may not even be Sprockets related.

Doing this is still :cry:. I wish custom modules could be passed to the `Engine` options and extended for just one `Engine` instance.

``` ruby
module MyFunctions
  def my_url(url)
  end
end

::Sass::Engine.new(css, {
  :functions => MyFunctions
})
```

cc @nex3 @rafaelfranca

Closes #518.
