### PR TITLE
when multiple manifest-*.json files exist in assets dir, use the last modified one

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -48,7 +48,7 @@ module Sprockets
         # Find the first manifest.json in the directory
         paths = Dir[File.join(@dir, "manifest*.json")]
         if paths.any?
-          @path = paths.first
+          @path = paths.sort_by{ |f| File.mtime(f) }.last
         else
           @path = File.join(@dir, "manifest-#{SecureRandom.hex(16)}.json")
         end

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -68,6 +68,24 @@ class TestManifest < Sprockets::TestCase
     assert_equal path, manifest.path
   end
 
+  test "specify manifest directory with multiple manifest-*.json" do
+    dir  = Dir::tmpdir
+    path1 = File.join(dir, 'manifest-123.json')
+    path2 = File.join(dir, 'manifest-456.json')
+
+    system "rm -rf #{dir}/manifest*.json"
+    File.open(path1, 'w') { |f| f.write "{}" }
+    sleep 1
+    File.open(path2, 'w') { |f| f.write "{}" }
+
+    assert File.exist?(path1)
+    assert File.exist?(path2)
+    manifest = Sprockets::Manifest.new(@env, dir)
+
+    assert_equal dir, manifest.dir
+    assert_equal path2, manifest.path
+  end
+
   test "specify manifest directory and seperate location" do
     root  = File.join(Dir::tmpdir, 'public')
     dir   = File.join(root, 'assets')


### PR DESCRIPTION
When we deploy to production, if the assets dir is not cleaned, there'll be historical manifest-*.json files. This is to ensure to use the latest one.
