### PR TITLE
Don't log INFO messages to `stderr`

### DIFF
--- a/lib/rake/sprocketstask.rb
+++ b/lib/rake/sprocketstask.rb
@@ -99,7 +99,7 @@ module Rake
       @environment  = lambda { Sprockets::Environment.new(Dir.pwd) }
       @manifest     = lambda { Sprockets::Manifest.new(index, output) }
       @logger       = Logger.new($stderr)
-      @logger.level = Logger::INFO
+      @logger.level = Logger::WARN
       @keep         = 2
 
       yield self if block_given?


### PR DESCRIPTION
The way the `logger` is used in `sprockets` is violating `POSIX` standards:
Only errors should go to `stderr`, not "INFO" messages.

I've attached a simple fix which sets the level to "WARN".

Perhaps a more correct solution would be to instantiate two loggers (one for `stdout`, one for `stderr`) and sending messages to the output appropriate for the level.
