### PR TITLE
Improve functionality of Manifest path and dir to accommodate "directory-only" path.

### DIFF
--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -66,20 +66,45 @@ class TestManifest < Sprockets::TestCase
 
     assert_equal dir, manifest.dir
     assert_equal path, manifest.path
+
+    manifest.send(:save)
+    assert File.exist?(path)
   end
 
-  test "specify manifest directory and seperate location" do
+  test "specify manifest directory and separate path with filename" do
     root  = File.join(Dir::tmpdir, 'public')
     dir   = File.join(root, 'assets')
-    path  = File.join(root, 'manifest-123.json')
+    path  = File.join(root, 'manifest-dir', 'manifest-123.json')
 
     system "rm -rf #{root}"
     assert !File.exist?(root)
+    assert !File.exist?(path)
 
     manifest = Sprockets::Manifest.new(@env, dir, path)
 
     assert_equal dir, manifest.dir
     assert_equal path, manifest.path
+
+    manifest.send(:save)
+    assert File.exist?(path)
+  end
+
+  test "specify manifest directory and separate path without filename" do
+    root  = File.join(Dir::tmpdir, 'public')
+    dir   = File.join(root, 'assets')
+    path  = File.join(root, 'manifest-dir')
+
+    system "rm -rf #{root}"
+    assert !File.exist?(root)
+    assert !File.exist?(path)
+
+    manifest = Sprockets::Manifest.new(@env, dir, path)
+
+    assert_equal dir, manifest.dir
+    assert_match %r{#{path}/manifest-.*\.json$}, manifest.path
+
+    manifest.send(:save)
+    assert File.exist?(manifest.path)
   end
 
   test "compile asset" do


### PR DESCRIPTION
Previously, the Manifest `:path` parameter had to be a full directory + filename. The `manifest-xxx.json` file path would only be generated if `:path` was blank but `:dir` was specified. Specifing `:path` as a directory w/o filename would cause an error at the time `Manifest#save` was called.

This commit fixes the behavior, adds several test cases which illustrate the change in functionality. The existing test cases seem to imply that this functionality should have worked, but was not explicitly covered.

This change does not affect existing functionality as far as I am aware, it merely adds support for a case  that was not supported previously (i.e. `:path` as directory w/o filename)

This is related to a change in Sprockets Rails to restore the `config.assets.manifest` option (discussion is here: https://github.com/rails/sprockets-rails/issues/107)
