### PR TITLE
Backport mkdir_p path fix for Manifest to 2.x branch

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -216,7 +216,7 @@ module Sprockets
 
       # Persist manfiest back to FS
       def save
-        FileUtils.mkdir_p dir
+        FileUtils.mkdir_p File.dirname(path)
         File.open(path, 'w') do |f|
           f.write json_encode(@data)
         end


### PR DESCRIPTION
Backport mkdir_p path fix for Manifest to 2.x branch
