### PR TITLE
sprockets 3.0 doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install Sprockets from RubyGems:
 
 Or include it in your project's `Gemfile` with Bundler:
 
-    gem 'sprockets', '~> 3.0'
+    gem 'sprockets', '~> 2.12'
 
 # Understanding the Sprockets Environment #
 


### PR DESCRIPTION
Not sure why people are encouraged to require a version of sprockets that doesn't actually exist.
