### PR TITLE
Use Marshal to dump string for hexdigest

### DIFF
--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -22,46 +22,13 @@ module Sprockets
       end
     end
 
-    # Internal: Generate a hexdigest for a nested JSON serializable object.
+    # Internal: Generate a hexdigest for a nested Marshalable object.
     #
-    # obj - A JSON serializable object.
+    # obj - A Marshalable object.
     #
     # Returns a String SHA1 digest of the object.
     def hexdigest(obj)
-      buf   = ""
-      queue = [obj]
-
-      while queue.length > 0
-        obj = queue.shift
-        klass = obj.class
-
-        if klass == String
-          buf << 'String'
-          buf << obj
-        elsif klass == Symbol
-          buf << 'Symbol'
-          buf << obj.to_s
-        elsif klass == Fixnum
-          buf << 'Fixnum'
-          buf << obj.to_s
-        elsif klass == TrueClass
-          buf << 'TrueClass'
-        elsif klass == FalseClass
-          buf << 'FalseClass'
-        elsif klass == NilClass
-          buf << 'NilClass'
-        elsif klass == Array
-          buf << 'Array'
-          queue.concat(obj)
-        elsif klass == Hash
-          buf << 'Hash'
-          queue.concat(obj.sort)
-        else
-          raise TypeError, "couldn't digest #{klass}"
-        end
-      end
-
-      ::Digest::SHA1.hexdigest(buf)
+      Digest::SHA1.hexdigest(Marshal.dump(obj))
     end
 
     def benchmark_start

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -5,21 +5,17 @@ class TestUtils < Sprockets::TestCase
   include Sprockets::Utils
 
   test "hexdigest" do
-    assert_equal "15e1d872b31958c396eaac1d61b9e46aa2f5531f", hexdigest(nil)
-    assert_equal "a88ea7cfcdafcd734a5e64234ba924227207df8c", hexdigest(true)
-    assert_equal "0d9c2b81e82b07d10af56e40a76d70f4b979549b", hexdigest(false)
-    assert_equal "58d7702df212c54f0a1f1f51b59f5ae988232ed8", hexdigest(42)
-    assert_equal "fb993f056be461ce93d6a846692c9fdfceb50b21", hexdigest("foo")
-    assert_equal "311a5592f7f7decd9b4b19d1350207a415c00608", hexdigest(:foo)
-    assert_equal "107004472b7ba4e5e31f3082ee1fb5a1239eec61", hexdigest([])
-    assert_equal "963e559076890aca4467f5b6abad3423808d3d17", hexdigest(["foo"])
-    assert_equal "627e644e75d24c60d2128f6be4a7b3156cc7cd65", hexdigest({"foo" => "bar"})
-    assert_equal "db5a9b24bbeecffcf6e0a289182a21d0d6013090", hexdigest({"foo" => "baz"})
-    assert_equal "422444d146220ad542c4a89409f9bb30dcb3702b", hexdigest([[:foo, 1]])
-    assert_equal "f7fcddffb6d8e5c089538f5d8ba32697df3bdc4f", hexdigest([{:foo => 1}])
-
-    assert_raises(TypeError) do
-      hexdigest(Object.new)
-    end
+    assert_equal "ab316bb112a477fa409c3020d34c2f2878fda76b", hexdigest(nil)
+    assert_equal "c91653ddbc97ebc06ce8f74455132acb0796489c", hexdigest(true)
+    assert_equal "1c8d0066bc059dae1626bf94d132c0890b3fe5e7", hexdigest(false)
+    assert_equal "f675e4b8f6d361f6636c71ca8c5dbc1d35582925", hexdigest(42)
+    assert_equal "cece4709cf686f8c8b62ad61adc4da8f75bf8a0f", hexdigest("foo")
+    assert_equal "b2817f7211c00bd368a2be200af4f1dd9ac74877", hexdigest(:foo)
+    assert_equal "a8442a027898a77c7b30fc41785141685d14701b", hexdigest([])
+    assert_equal "e3c69947361aad09ce9927bc0f622ee36063cdb6", hexdigest(["foo"])
+    assert_equal "838038ad67c6d3392dbdf6325a6e32846f0c3071", hexdigest({"foo" => "bar"})
+    assert_equal "eca5033f779fad6ce036f1cf962563c09acfd0c8", hexdigest({"foo" => "baz"})
+    assert_equal "fa22d4603e816bde8d0d77efe13e8b97d4ba8668", hexdigest([[:foo, 1]])
+    assert_equal "a050c68845181bb89ffa2f988c200ba425de0034", hexdigest([{:foo => 1}])
   end
 end


### PR DESCRIPTION
- [ ] More benchmarking
- [ ] Tests are inconsistent across rubies
