### PR TITLE
Change WOFF MIME type to `application/font-woff`

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -84,7 +84,7 @@ module Sprockets
   # Common font types
   register_mime_type 'application/vnd.ms-fontobject', extensions: ['.eot']
   register_mime_type 'application/x-font-ttf', extensions: ['.ttf']
-  register_mime_type 'application/x-font-woff', extensions: ['.woff']
+  register_mime_type 'application/font-woff', extensions: ['.woff']
 
   # HTTP content encodings
   register_encoding :deflate, EncodingUtils::DEFLATE


### PR DESCRIPTION
The WOFF MIME Type was formally registered as `application/font-woff`:
http://www.iana.org/assignments/media-types/application/font-woff
## 

@josh also, recently [WOFF 2.0](http://www.w3.org/TR/WOFF2/) was introduced, but [there isn't yet a recommended file extension and MIME type](https://github.com/h5bp/server-configs-apache/issues/32#issuecomment-46683006) for it.
