### PR TITLE
Add docs badge to contribution section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ within any subdependencies.
 
 # Development #
 
-## Contributing ##
+## Contributing [![Inline docs](http://inch-ci.org/github/sstephenson/sprockets.png?branch=master)](http://inch-ci.org/github/sstephenson/sprockets) ##
 
 The Sprockets source code is [hosted on
 GitHub](https://github.com/sstephenson/sprockets). You can check out a


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the _Contributing_ section of the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/sstephenson/sprockets.png)](http://inch-ci.org/github/sstephenson/sprockets)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/sstephenson/sprockets/

Inch CI is still in its infancy, but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
