### PR TITLE
Improve If-Match support

### DIFF
--- a/lib/sprockets/cached_environment.rb
+++ b/lib/sprockets/cached_environment.rb
@@ -61,12 +61,6 @@ module Sprockets
         ]
       end
 
-      def build_asset_hash_for_digest(*args)
-        cache.fetch(asset_hash_cache_key(*args)) do
-          super
-        end
-      end
-
       # Cache asset building in memory and in persisted cache.
       def build_asset_hash(filename, options)
         digest_key = asset_digest_cache_key(filename, options)

--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -25,9 +25,10 @@ module Sprockets
     end
     alias_method :index, :cached
 
-    # Cache `find_asset` calls
-    def find_asset(path, options = {})
-      cached.find_asset(path, options)
-    end
+    protected
+      # Ensure `find_asset_with_status` calls are always involved on a cached environment.
+      def find_asset_with_status(*args)
+        cached.find_asset_with_status(*args)
+      end
   end
 end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -345,6 +345,21 @@ $app.run(function($templateCache) {
     asset = @env.find_asset("gallery.js")
     assert @env.find_asset("gallery.js", if_match: asset.etag)
     refute @env.find_asset("gallery.js", if_match: "0000000000000000000000000000000000000000")
+    refute @env.find_asset("missing.js", if_match: "0000000000000000000000000000000000000000")
+  end
+
+  test "find asset not matching etag" do
+    assert asset = @env.find_asset("gallery.js")
+    refute @env.find_asset("gallery.js", if_none_match: asset.etag)
+    assert @env.find_asset("gallery.js", if_none_match: "0000000000000000000000000000000000000000")
+    refute @env.find_asset("missing.js", if_none_match: "0000000000000000000000000000000000000000")
+  end
+
+  test "find with if and if none match" do
+    assert asset = @env.find_asset("gallery.js")
+    refute @env.find_asset("gallery.js", if_match: asset.etag, if_none_match: asset.etag)
+    refute @env.find_asset("gallery.js", if_match: "0000000000000000000000000000000000000000", if_none_match: "0000000000000000000000000000000000000000")
+    refute @env.find_asset("missing.js", if_match: "0000000000000000000000000000000000000000", if_none_match: "0000000000000000000000000000000000000000")
   end
 
   test "missing static path returns nil" do


### PR DESCRIPTION
- [x] Change `find_asset` to understand the difference between missing assets and wrong etags.
- [x] Test how fingerprinted paths and `If-Match` headers should be chosen over each other.
