### PR TITLE
Bundle map/reduce

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -17,12 +17,10 @@ module Sprockets
   autoload :EcoTemplate,             'sprockets/eco_template'
   autoload :EjsTemplate,             'sprockets/ejs_template'
   autoload :ERBTemplate,             'sprockets/erb_template'
-  autoload :JavascriptBundle,        'sprockets/bundle'
   autoload :JstProcessor,            'sprockets/jst_processor'
   autoload :SassCompressor,          'sprockets/sass_compressor'
   autoload :SassTemplate,            'sprockets/sass_template'
   autoload :ScssTemplate,            'sprockets/sass_template'
-  autoload :StylesheetBundle,        'sprockets/bundle'
   autoload :UglifierCompressor,      'sprockets/uglifier_compressor'
   autoload :YUICompressor,           'sprockets/yui_compressor'
 
@@ -52,6 +50,7 @@ module Sprockets
   @transformers      = Hash.new { |h, k| {}.freeze }.freeze
   @preprocessors     = Hash.new { |h, k| [].freeze }.freeze
   @postprocessors    = Hash.new { |h, k| [].freeze }.freeze
+  @bundle_reducers   = Hash.new { |h, k| {}.freeze }.freeze
   @bundle_processors = Hash.new { |h, k| [].freeze }.freeze
   @compressors       = Hash.new { |h, k| {}.freeze }.freeze
   @context_class     = Context
@@ -108,8 +107,12 @@ module Sprockets
   register_preprocessor 'text/css', DirectiveProcessor
   register_preprocessor 'application/javascript', DirectiveProcessor
 
-  register_bundle_processor 'application/javascript', JavascriptBundle
-  register_bundle_processor 'text/css', StylesheetBundle
+  register_bundle_processor 'application/javascript', Bundle
+  register_bundle_processor 'text/css', Bundle
+
+  register_bundle_reducer '*/*', :data, :+
+  register_bundle_reducer 'application/javascript', :data, Utils.method(:concat_javascript_sources)
+  register_bundle_reducer '*/*', :dependency_paths, :+
 
   register_compressor 'text/css', :sass, LazyProcessor.new { SassCompressor }
   register_compressor 'text/css', :scss, LazyProcessor.new { SassCompressor }

--- a/lib/sprockets/bundle.rb
+++ b/lib/sprockets/bundle.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Sprockets
   # Internal: Bundle processor takes a single file asset and prepends all the
   # `:required_paths` to the contents.
@@ -13,95 +11,25 @@ module Sprockets
   # Also see DirectiveProcessor.
   class Bundle
     def self.call(input)
-      new.call(input)
-    end
-
-    DEFAULT_REDUCERS = {
-      data: proc { |data, asset|
-        data ||= "".force_encoding(Encoding::UTF_8)
-        data << asset.to_s
-      },
-
-      dependency_paths: proc { |paths, asset|
-        paths ||= Set.new
-        paths.merge(asset.metadata[:dependency_paths])
-      },
-
-      # Deprecated: For Asset#to_a
-      required_asset_hashes: proc { |hashes, asset|
-        hashes ||= []
-        hashes << asset.to_hash
-      }
-    }.freeze
-
-    def initialize(options = {})
-      options[:reducers] ||= {}
-      @reducers = DEFAULT_REDUCERS.merge(options[:reducers])
-    end
-
-    def call(input)
       env      = input[:environment]
       filename = input[:filename]
       type     = input[:content_type]
 
-      assets = Hash.new do |h, path|
-        unless asset = env.find_asset(path, bundle: false, accept: type)
+      cache = Hash.new do |h, path|
+        unless env.file?(path)
           raise FileNotFound, "could not find #{path}"
         end
-        h[path] = asset
+        # TODO: Avoid using internal build_asset_hash API
+        h[path] = env.send(:build_asset_hash, path, bundle: false, accept: type)
       end
 
-      find_required_paths = proc { |path| assets[path].metadata[:required_paths] }
+      find_required_paths = proc { |path| cache[path][:metadata][:required_paths] }
       required_paths = Utils.dfs(filename, &find_required_paths)
-      stubbed_paths  = Utils.dfs(assets[filename].metadata[:stubbed_paths], &find_required_paths)
+      stubbed_paths  = Utils.dfs(cache[filename][:metadata][:stubbed_paths], &find_required_paths)
       required_paths.subtract(stubbed_paths)
+      assets = required_paths.map { |path| cache[path] }
 
-      required_paths.reduce({}) do |h, path|
-        asset = assets[path]
-        @reducers.each { |k, fn| h[k] = fn.call(h[k], asset) }
-        h
-      end
-    end
-  end
-
-  class StylesheetBundle < Bundle
-  end
-
-  class JavascriptBundle < Bundle
-
-    def initialize(options = {})
-      options[:reducers] ||= {}
-      options[:reducers][:data] = proc { |data, asset|
-        data ||= "".force_encoding(Encoding::UTF_8)
-        contents = asset.to_s
-        if JavascriptBundle.missing_semicolon?(contents)
-          data << contents << ";\n"
-        else
-          data << contents
-        end
-      }
-      super(options)
-    end
-
-    # Internal: Check if data is missing a trailing semicolon.
-    #
-    # data - String
-    #
-    # Returns true or false.
-    def self.missing_semicolon?(data)
-      i = data.size - 1
-      while i >= 0
-        c = data[i]
-        i -= 1
-        if c == "\n" || c == " " || c == "\t"
-          next
-        elsif c != ";"
-          return true
-        else
-          return false
-        end
-      end
-      false
+      env.process_bundle_reducers(assets, env.unwrap_bundle_reducers(type))
     end
   end
 end

--- a/lib/sprockets/configuration.rb
+++ b/lib/sprockets/configuration.rb
@@ -24,6 +24,7 @@ module Sprockets
       @transformers      = parent.transformers
       @preprocessors     = parent.preprocessors
       @postprocessors    = parent.postprocessors
+      @bundle_reducers   = parent.bundle_reducers
       @bundle_processors = parent.bundle_processors
       @compressors       = parent.compressors
     end

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -6,7 +6,43 @@ module Sprockets
   module Utils
     extend self
 
-    # Prepends a leading "." to an extension if its missing.
+    # Internal: Check if string has a trailing semicolon.
+    #
+    # str - String
+    #
+    # Returns true or false.
+    def string_end_with_semicolon?(str)
+      i = str.size - 1
+      while i >= 0
+        c = str[i]
+        i -= 1
+        if c == "\n" || c == " " || c == "\t"
+          next
+        elsif c != ";"
+          return false
+        else
+          return true
+        end
+      end
+      true
+    end
+
+    # Internal: Accumulate asset source to buffer and append a trailing
+    # semicolon if necessary.
+    #
+    # buf   - String memo
+    # asset - Asset
+    #
+    # Returns appended buffer String.
+    def concat_javascript_sources(buf, source)
+      if string_end_with_semicolon?(buf)
+        buf + source
+      else
+        buf + ";\n" + source
+      end
+    end
+
+    # Internal: Prepends a leading "." to an extension if its missing.
     #
     #     normalize_extension("js")
     #     # => ".js"

--- a/test/fixtures/context/environment.js.erb
+++ b/test/fixtures/context/environment.js.erb
@@ -1,2 +1,2 @@
 //= require environment-dep
-<%= environment.class %>:<%= environment.object_id %>
+<%= environment.class %>:<%= environment.object_id %>;

--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -87,12 +87,7 @@ JS2HTMLIMPORT = proc { |input|
 }
 Sprockets.register_transformer 'application/javascript', 'text/html', JS2HTMLIMPORT
 
-Sprockets.register_bundle_processor 'text/css', proc { |input|
-  selector_count = input[:metadata][:required_asset_hashes].inject(0) { |n, asset|
-    n + asset[:metadata][:selector_count]
-  }
-  { data: input[:data], selector_count: selector_count }
-}
+Sprockets.register_bundle_reducer 'text/css', :selector_count, :+
 
 Sprockets.register_postprocessor 'text/css', proc { |input|
   { data: input[:data],

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -759,7 +759,7 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "appends missing semicolons" do
-    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n;\n",
+    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n",
       asset("semicolons.js").to_s
   end
 

--- a/test/test_bundle.rb
+++ b/test/test_bundle.rb
@@ -16,7 +16,7 @@ class TestStylesheetBundle < Sprockets::TestCase
     }
 
     data = ".project {}\n"
-    result = Sprockets::StylesheetBundle.call(input)
+    result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [filename], result[:dependency_paths].to_a.sort
   end
@@ -36,7 +36,7 @@ class TestStylesheetBundle < Sprockets::TestCase
     }
 
     data = "/* b.css */\n\nb { display: none }\n/*\n\n\n\n */\n\n\nbody {}\n.project {}\n"
-    result = Sprockets::StylesheetBundle.call(input)
+    result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [
       fixture_path('asset/project.css'),
@@ -44,9 +44,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       fixture_path('asset/tree/all/b.css')
     ], result[:dependency_paths].to_a.sort
   end
-end
 
-class TestJavascriptBundle < Sprockets::TestCase
   test "bundle single javascript file" do
     environment = Sprockets::Environment.new
     environment.append_path fixture_path('asset')
@@ -62,7 +60,7 @@ class TestJavascriptBundle < Sprockets::TestCase
     }
 
     data = "var Project = {\n  find: function(id) {\n  }\n};\n"
-    result = Sprockets::JavascriptBundle.call(input)
+    result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [filename], result[:dependency_paths].to_a.sort
   end
@@ -82,7 +80,7 @@ class TestJavascriptBundle < Sprockets::TestCase
     }
 
     data = "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n"
-    result = Sprockets::JavascriptBundle.call(input)
+    result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [
       fixture_path('asset/application.js'),

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -122,6 +122,6 @@ class TestCustomProcessor < Sprockets::TestCase
     assert_equal [fixture_path("context/foo.js"),
      fixture_path("context/foo.js"),
      fixture_path("context/foo.js")
-    ].join(",\n") + ";", @env["resolve_content_type.js"].to_s.strip
+    ].join(",\n"), @env["resolve_content_type.js"].to_s.strip
   end
 end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -68,7 +68,7 @@ $app.run(function($templateCache) {
 
   test "lookup bundle processors" do
     assert_equal 1, @env.bundle_processors['application/javascript'].size
-    assert_equal 2, @env.bundle_processors['text/css'].size
+    assert_equal 1, @env.bundle_processors['text/css'].size
   end
 
   test "find asset with accept type" do
@@ -720,7 +720,7 @@ class TestEnvironment < Sprockets::TestCase
 
   test "disabling default directive preprocessor" do
     @env.unregister_preprocessor('application/javascript', Sprockets::DirectiveProcessor)
-    assert_equal "// =require \"notfound\"\n;\n", @env["missing_require.js"].to_s
+    assert_equal "// =require \"notfound\"\n", @env["missing_require.js"].to_s
   end
 end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -5,6 +5,31 @@ require 'sprockets/utils'
 class TestUtils < Sprockets::TestCase
   include Sprockets::Utils
 
+  test "string ends with semicolon" do
+    assert string_end_with_semicolon?("var foo;")
+    refute string_end_with_semicolon?("var foo")
+
+    assert string_end_with_semicolon?("var foo;\n")
+    refute string_end_with_semicolon?("var foo\n")
+
+    assert string_end_with_semicolon?("var foo;\n\n")
+    refute string_end_with_semicolon?("var foo\n\n")
+
+    assert string_end_with_semicolon?("  var foo;\n  \n")
+    refute string_end_with_semicolon?("  var foo\n  \n")
+
+    assert string_end_with_semicolon?("\tvar foo;\n\t\n")
+    refute string_end_with_semicolon?("\tvar foo\n\t\n")
+
+    assert string_end_with_semicolon?("var foo\n;\n")
+    refute string_end_with_semicolon?("var foo\n\n")
+  end
+
+  test "concat javascript sources" do
+    assert_equal "var foo;\nvar bar;\n", concat_javascript_sources("var foo;\n", "var bar;\n")
+    assert_equal "var foo;\nvar bar", concat_javascript_sources("var foo", "var bar")
+  end
+
   test "hexdigest" do
     assert_equal "15e1d872b31958c396eaac1d61b9e46aa2f5531f", hexdigest(nil)
     assert_equal "a88ea7cfcdafcd734a5e64234ba924227207df8c", hexdigest(true)


### PR DESCRIPTION
Hey @aroben.

I wanted to make sure it'd be :cake: add processors that generated metadata on every asset and then aggregated it during the bundle process.

The process should be
1. Define a pre/post processor to generate metadata per file. Thats pretty simple now we have processor metadata.
2. Define a bundle processor to aggregate many asset metadata pieces into a single value. This part is less clear right now. We have an exposed "required_asset_hashes" set of assets, but its considered internal and deprecated. So I think that needs to be formalized somehow.
