### PR TITLE
Add security fix for /../ path expansion

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'tempfile'
+require 'pathname'
 
 module Sprockets
   # Internal: File and path related utilities. Mixed into Environment.
@@ -83,7 +84,9 @@ module Sprockets
     # Returns relative String path if subpath is a subpath of path, or nil if
     # subpath is outside of path.
     def split_subpath(path, subpath)
-      path = File.join(path, '')
+      path = Pathname.new(path).cleanpath.to_s + "/"
+      subpath = Pathname.new(subpath).cleanpath.to_s
+
       if subpath.start_with?(path)
         subpath[path.length..-1]
       else

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -402,6 +402,17 @@ $app.run(function($templateCache) {
     end
   end
 
+  test "asset absolute path is smart enough to expand /../" do
+    env = Sprockets::Environment.new(".") do |env|
+      env.append_path(File.join(fixture_path('default'), 'app'))
+      env.cache = {}
+    end
+
+    assert_raises Sprockets::FileOutsidePaths do
+      env[fixture_path("default/app/../gallery.js")]
+    end
+  end
+
   test "asset logical path for absolute path" do
     assert_equal "gallery.js",
       @env[fixture_path("default/gallery.js")].logical_path

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -72,6 +72,10 @@ class TestPathUtils < Sprockets::TestCase
     refute paths_split([fixture_path("default")], fixture_path("other/app/application.js"))
   end
 
+  test "path with /../" do
+    assert_nil paths_split([fixture_path("default")], fixture_path("default/../../../../application.js"))
+  end
+
   test "path extensions" do
     assert_equal [".txt"], path_extnames("hello.txt")
     assert_equal [".txt"], path_extnames("sub/hello.txt")


### PR DESCRIPTION
### Problem

Sprockets::Environment#find_asset does not properly expand paths that contain things like "/../", thus potentially allowing to access assets that are outside of Sprockets::Environment#paths.

This is particularly dangerous in combination with [asset_data_url](https://github.com/rails/sass-rails/blob/ae7e785e67986389195067ba990653ebb5829b32/lib/sass/rails/helpers.rb#L27) from sass-rails when compiling user-supplied SCSS input.

An attacker could use the following SCSS to read arbitrary files on the server:

``` scss
body {
  background: asset-data-url('/somewhere/rails/app/assets/stylesheets/../../../config/secrets.json');
}
```
### Example

Allowed paths could be ["/foo/bar/"] and find_asset could be called on "/foo/bar/../asset". Since the [validation](https://github.com/fw42/sprockets/blob/43c55841e55ef5894421c45f1ed62bc22240aec3/lib/sprockets/path_utils.rb#L90) is a very simple `if subpath.start_with?(path)`, this will go through, since "/foo/bar/../asset" does start with "/foo/bar/", even though it's not located in the /foo/bar/ directory.
### Solution

Call [Pathname#cleanpath](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/pathname/rdoc/Pathname.html#method-i-cleanpath) on the paths.
### Review

Please review @sstephenson @josh
cc @rafaelfranca @arthurnn for sass-rails opinions
cc @ibawt @cjoudrey @einstein-
