### PR TITLE
Add base64_digest for subresource integrity

### DIFF
--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -167,8 +167,9 @@ module Sprockets
     # Public: Returns String hexdigest of source.
     attr_reader :digest
 
-    # Public: Returns the String base64 digest of source.
-    attr_reader :base64_digest
+    # Public: A "named information" URL specifying the base64 SHA256 digest of
+    # the asset.
+    attr_reader :integrity
 
     # Pubic: ETag String of Asset.
     alias_method :etag, :digest

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -192,7 +192,7 @@ module Sprockets
             encoding: Encoding::BINARY,
             length: self.stat(asset[:filename]).size,
             digest: digest_class.file(asset[:filename]).hexdigest,
-            base64_digest: digest_class.file(asset[:filename]).base64digest,
+            integrity: Utils.integrity_uri(File.read(asset[:filename])),
             metadata: {}
           })
         end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -170,11 +170,11 @@ module Sprockets
       filter_logical_paths(*args).each do |_, filename|
         find_assets(filename) do |asset|
           files[asset.digest_path] = {
-            'logical_path'  => asset.logical_path,
-            'mtime'         => asset.mtime.iso8601,
-            'size'          => asset.bytesize,
-            'digest'        => asset.digest,
-            'base64_digest' => asset.base64_digest
+            'logical_path' => asset.logical_path,
+            'mtime'        => asset.mtime.iso8601,
+            'size'         => asset.bytesize,
+            'digest'       => asset.digest,
+            'integrity'    => asset.integrity
           }
           assets[asset.logical_path] = asset.digest_path
 

--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -196,7 +196,7 @@ module Sprockets
         charset: data.encoding.name.downcase,
         length: data.bytesize,
         digest: digest_class.hexdigest(data),
-        base64_digest: digest_class.base64digest(data),
+        integrity: Utils.integrity_uri(data),
         metadata: metadata
       }
     end

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -1,10 +1,34 @@
-require 'digest/sha1'
+require 'digest'
+require 'base64'
+require 'cgi'
 require 'set'
 
 module Sprockets
   # `Utils`, we didn't know where else to put it!
   module Utils
     extend self
+
+    # Internal: Generate a "named information" URI for use in the `integrity`
+    # attribute of an asset tag as per the subresource integrity specification.
+    #
+    # content      - The content of the asset to generate the URI for.
+    # content_type - The content-type the asset will be served with. This *must*
+    #                be accurate if provided. Otherwise, subresource integrity
+    #                will block the loading of the asset.
+    #
+    # Returns a String.
+    def integrity_uri(content, content_type = nil)
+      # Prepare/format the digest.
+      digest = ::Digest::SHA256.digest(content)
+      digest = Base64.urlsafe_encode64(digest)
+      digest = digest.sub(/=*\z/, "")
+
+      # Prepare/format the query section.
+      query = content_type ? "?ct=#{CGI.escape(content_type)}" : ""
+
+      # Build the URI.
+      "ni:///sha-256;#{digest}#{query}"
+    end
 
     # Internal: Check if string has a trailing semicolon.
     #

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -28,8 +28,12 @@ module AssetTests
     assert_equal Digest::SHA1.hexdigest(@asset.to_s), @asset.digest
   end
 
-  test "base64_digest is source base64 digest" do
-    assert_equal Digest::SHA1.base64digest(@asset.to_s), @asset.base64_digest
+  test "integrity is properly generated" do
+    digest = ::Digest::SHA256.digest(@asset.to_s)
+    digest = Base64.urlsafe_encode64(digest)
+    digest = digest.sub(/=*\z/, "")
+    expected = "ni:///sha-256;#{digest}"
+    assert_equal expected, @asset.integrity
   end
 
   test "length is source length" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -5,6 +5,16 @@ require 'sprockets/utils'
 class TestUtils < Sprockets::TestCase
   include Sprockets::Utils
 
+  test "integrity_uri properly formats the named information URI" do
+    expected = "ni:///sha-256;bhHHL3z2vDgxUt0W3dWQOrprscmda2Y5pLsLg4GF-pI"
+    assert_equal expected, integrity_uri("alert(1)")
+  end
+
+  test "integrity_uri adds an encoded content-type if given one" do
+    expected = "ni:///sha-256;bhHHL3z2vDgxUt0W3dWQOrprscmda2Y5pLsLg4GF-pI?ct=application%2Fjavascript"
+    assert_equal expected, integrity_uri("alert(1)", "application/javascript")
+  end
+
   test "string ends with semicolon" do
     assert string_end_with_semicolon?("var foo;")
     refute string_end_with_semicolon?("var foo")


### PR DESCRIPTION
This PR adds `Asset#integrity` to simplify the implementation of [subresource integrity](http://www.w3.org/TR/SRI/#htmlscriptelement-1).

/cc @josh
