### PR TITLE
fix tilt dependency

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "hike", "~> 1.2"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "rack", "~> 1.0"
-  s.add_dependency "tilt", ["~> 1.1", "!= 1.3.0"]
+  s.add_dependency "tilt", ["~> 1.3"]
 
   s.add_development_dependency "closure-compiler"
   s.add_development_dependency "coffee-script", "~> 2.0"


### PR DESCRIPTION
sprockets needs tilt ~>1.3.1, otherwise tests do not pass and you have
this error:

/lib/sprockets/jst_processor.rb:5:in class:JstProcessor': undefined
methoddefault_mime_type=' for Sprockets::JstProcessor:Class
(NoMethodError)"

this commit fixes issue #642
