### PR TITLE
Add missing = in the link directive example

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ For an example, in a CSS file you might reference an external image that always
 needs to be compiled along with the css file.
 
 ``` css
-/* link "logo.png" */
+/*= link "logo.png" */
 .logo {
   background-image: url(logo.png)
 }


### PR DESCRIPTION
The example seems to lack = to make it actually work as a Sprocket directive.