### PR TITLE
Come back constants about charset

### DIFF
--- a/lib/sprockets/encoding_utils.rb
+++ b/lib/sprockets/encoding_utils.rb
@@ -111,7 +111,7 @@ module Sprockets
 
       str
     end
-    CHARSET_DETECT[:default] = method(:detect)
+    DETECT = CHARSET_DETECT[:default] = method(:detect)
 
     # Internal: Use Charlock Holmes to detect encoding.
     #
@@ -145,7 +145,7 @@ module Sprockets
 
       str
     end
-    CHARSET_DETECT[:unicode] = method(:detect_unicode)
+    DETECT_UNICODE = CHARSET_DETECT[:unicode] = method(:detect_unicode)
 
     # Public: Detect and strip BOM from possible unicode string.
     #
@@ -193,7 +193,7 @@ module Sprockets
 
       str
     end
-    CHARSET_DETECT[:css] = method(:detect_css)
+    DETECT_CSS = CHARSET_DETECT[:css] = method(:detect_css)
 
     # Internal: @charset bytes
     CHARSET_START = [0x40, 0x63, 0x68, 0x61, 0x72, 0x73, 0x65, 0x74, 0x20, 0x22]
@@ -253,6 +253,6 @@ module Sprockets
 
       str
     end
-    CHARSET_DETECT[:html] = method(:detect_html)
+    DETECT_HTML = CHARSET_DETECT[:html] = method(:detect_html)
   end
 end


### PR DESCRIPTION
These constant variables are removed in 9c01b7e67.
But it seems that they were [public API](https://github.com/sstephenson/sprockets/commit/9c01b7e6747904cbac9dc6a0e32b912dcf8f15c6#diff-73e8aa4b46ac54569276e0105a96b280L119).

To backward compatibility, old constants should be defined.