### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - rbx-2
 
 notifications:
   email: false
+  
+matrix:
+  allow_failures:
+    - rvm: rbx-2


### PR DESCRIPTION
Adding Rubinius to build matrix to verify that Sprockets work on Rubinius.  I would appreciate if you could add this to your build matrix so we can ensure Sprockets works on Rubinius. Thank you.