### PR TITLE
Added a "paths" rake task

### DIFF
--- a/lib/rake/sprocketstask.rb
+++ b/lib/rake/sprocketstask.rb
@@ -134,6 +134,15 @@ module Rake
       end
 
       task :clean => ["clean_#{name}"]
+
+      desc name == :assets ? "Print asset paths" : "Print #{name} asset paths"
+      task "#{name}_paths" do
+        with_logger do
+          environment.paths.each { |path| puts path }
+        end
+      end
+
+      task :paths => ["#{name}_paths"]
     end
 
     private

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -86,4 +86,19 @@ class TestRakeTask < Sprockets::TestCase
     assert Dir["#{@dir}/manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
+
+  test "paths" do
+    begin
+      fake_stdout = StringIO.new
+      $stdout = fake_stdout
+
+      @rake[:paths].invoke
+
+      fake_stdout.close
+
+      assert_equal fake_stdout.string, "#{fixture_path('default')}\n"
+    ensure
+      $stdout = STDOUT
+    end
+  end
 end


### PR DESCRIPTION
This rake task prints out the paths in the order that they are defined, to aid debugging load path issues.

I've had problems recently when I've had multiple versions of the same library in my asset paths, and found out that I've been loading the wrong one (for example, if you use more than one gem that includes `jquery.js`). I think that having a rake task to print out the asset paths would be very useful for this reason.