### PR TITLE
fix erroneously added newline

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -75,9 +75,20 @@ module Sprockets
       @pathname = Pathname.new(file)
 
       @header = data[HEADER_PATTERN, 0] || ""
-      @body   = ($'.nil?) ? data : $'.sub("\n", "")
+      @body   = $' || data
       # Ensure body ends in a new line
       @body  += "\n" if @body != "" && @body !~ /\n\Z/m
+
+      # Deal with regex missing the last newline char when
+      # the header uses \* *\, e.g.
+      #
+      # /* global Foo */
+      # /* global Bar */
+      #
+      unless @header.end_with?($/)
+        @body.sub!($/, "")
+        @header += $/
+      end
 
       @included_pathnames = []
       @compat             = false

--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -75,7 +75,7 @@ module Sprockets
       @pathname = Pathname.new(file)
 
       @header = data[HEADER_PATTERN, 0] || ""
-      @body   = $' || data
+      @body   = ($'.nil?) ? data : $'.sub("\n", "")
       # Ensure body ends in a new line
       @body  += "\n" if @body != "" && @body !~ /\n\Z/m
 


### PR DESCRIPTION
`HEADER_PATTERN` is a regex that Sprockets uses to find the header section of a js file in preparation for scanning it for directives. `$'` is ruby shorthand for the global postmatch regex variable.

Unfortunately, the `HEADER_PATTERN` regex matches until right before the final `\n` of the js header. So this `\n` then gets added to the `$'` var, in turn causing the `@body` var to start with a `\n` char.

This causes js code like this

```
/* global Ember */
/* global SwrveEmber */

(function () {
  "use strict";
  ...
}
```
to get loaded into the rails app with an extra newline, like so

```
/* global Ember */
/* global SwrveEmber */


(function () {
  "use strict";
  ...
}
```

this in turn doesn't play nice with code coverage tools, as the line numbers generated by the coverage tools are off by one with the line numbers of the source files.