### PR TITLE
Remove message not to disclose full path in the browser.

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -106,9 +106,9 @@ module Sprockets
       # Returns a JavaScript response that re-throws a Ruby exception
       # in the browser
       def javascript_exception_response(exception)
-        err  = "#{exception.class.name}: #{exception.message}"
+        err  = "#{exception.class.name}"
         body = "throw Error(#{err.inspect})"
-        [ 200, { "Content-Type" => "application/javascript", "Content-Length" => Rack::Utils.bytesize(body).to_s }, [ body ] ]
+        [ 500, { "Content-Type" => "application/javascript", "Content-Length" => Rack::Utils.bytesize(body).to_s }, [ body ] ]
       end
 
       # Returns a CSS response that hides all elements on the page and
@@ -161,7 +161,7 @@ module Sprockets
           }
         CSS
 
-        [ 200, { "Content-Type" => "text/css;charset=utf-8", "Content-Length" => Rack::Utils.bytesize(body).to_s }, [ body ] ]
+        [ 500, { "Content-Type" => "text/css;charset=utf-8", "Content-Length" => Rack::Utils.bytesize(body).to_s }, [ body ] ]
       end
 
       # Escape special characters for use inside a CSS content("...") string

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -189,13 +189,13 @@ class TestServer < Sprockets::TestCase
 
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
-    assert_equal 200, last_response.status
-    assert_equal "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound'\\n  (in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)\")", last_response.body
+    assert_equal 500, last_response.status
+    assert_equal "throw Error(\"Sprockets::FileNotFound\")", last_response.body
   end
 
   test "display CSS exceptions in the browser" do
     get "/assets/missing_require.css"
-    assert_equal 200, last_response.status
+    assert_equal 500, last_response.status
     assert_match %r{content: ".*?Sprockets::FileNotFound}, last_response.body
   end
 


### PR DESCRIPTION
When displayed file path in the browser, it might be happened directly traversal. So I will send this pull request not to display file path. 
And the response code should not be 200 since actually it's not OK. Logger also put message as Internal Server Error. So I will request also to change from 200 to 500 when Ruby has exception by loading Javascript/CSS.
Please confirm my pull request. Best Regards,
